### PR TITLE
 Fix for api changes in ballerina-lang

### DIFF
--- a/kafka-native/src/main/java/org/ballerinalang/messaging/kafka/serdes/BallerinaKafkaDeserializer.java
+++ b/kafka-native/src/main/java/org/ballerinalang/messaging/kafka/serdes/BallerinaKafkaDeserializer.java
@@ -25,6 +25,7 @@ import org.ballerinalang.jvm.values.ObjectValue;
 import org.ballerinalang.jvm.values.api.BArray;
 import org.ballerinalang.jvm.values.api.BValueCreator;
 import org.ballerinalang.messaging.kafka.utils.KafkaConstants;
+import org.ballerinalang.messaging.kafka.utils.KafkaUtils;
 
 import java.util.Map;
 import java.util.Objects;
@@ -59,13 +60,14 @@ public class BallerinaKafkaDeserializer implements Deserializer {
     public Object deserialize(String topic, byte[] data) {
         BArray bData = BValueCreator.createArrayValue(data);
         Object[] args = new Object[]{bData, false};
-        return this.runtime.getSyncMethodInvokeResult(this.deserializerObject, KafkaConstants.FUNCTION_DESERIALIZE,
-                                                      null, ON_DESERIALIZE_METADATA, this.timeout, args);
+        return KafkaUtils.invokeMethodSync(runtime, this.deserializerObject, KafkaConstants.FUNCTION_DESERIALIZE,
+                                           null, ON_DESERIALIZE_METADATA, this.timeout, args);
     }
 
     @Override
     public void close() {
-        this.runtime.getSyncMethodInvokeResult(this.deserializerObject, KafkaConstants.FUNCTION_CLOSE,
-                                               null, ON_CLOSE_METADATA, this.timeout);
+        KafkaUtils.invokeMethodSync(runtime, this.deserializerObject, KafkaConstants.FUNCTION_CLOSE,
+                                    null, ON_CLOSE_METADATA, this.timeout);
     }
+
 }

--- a/kafka-native/src/main/java/org/ballerinalang/messaging/kafka/serdes/BallerinaKafkaSerializer.java
+++ b/kafka-native/src/main/java/org/ballerinalang/messaging/kafka/serdes/BallerinaKafkaSerializer.java
@@ -24,6 +24,7 @@ import org.ballerinalang.jvm.BRuntime;
 import org.ballerinalang.jvm.values.ObjectValue;
 import org.ballerinalang.jvm.values.api.BArray;
 import org.ballerinalang.messaging.kafka.utils.KafkaConstants;
+import org.ballerinalang.messaging.kafka.utils.KafkaUtils;
 
 import java.util.Map;
 
@@ -51,16 +52,15 @@ public class BallerinaKafkaSerializer implements Serializer {
     @Override
     public byte[] serialize(String topic, Object data) {
         Object[] args = new Object[]{data, false};
-        BArray result = (BArray) BRuntime.getCurrentRuntime()
-                .getSyncMethodInvokeResult(this.serializerObject, KafkaConstants.FUNCTION_SERIALIZE, null,
-                                           ON_SERIALIZE_METADATA, timeout, args);
+        BArray result = (BArray) KafkaUtils.invokeMethodSync(BRuntime.getCurrentRuntime(), this.serializerObject,
+                                                             KafkaConstants.FUNCTION_SERIALIZE, null,
+                                                             ON_SERIALIZE_METADATA, timeout, args);
         return result.getBytes();
     }
 
     @Override
     public void close() {
-        BRuntime.getCurrentRuntime()
-                .getSyncMethodInvokeResult(this.serializerObject, KafkaConstants.FUNCTION_CLOSE, null,
-                                           ON_CLOSE_METADATA, timeout);
+        KafkaUtils.invokeMethodSync(BRuntime.getCurrentRuntime(), this.serializerObject, KafkaConstants.FUNCTION_CLOSE,
+                                    null, ON_CLOSE_METADATA, timeout);
     }
 }


### PR DESCRIPTION
## Purpose
> The sync method call apis have been removed. This fix is for the api change involved.

## Goals
> Fix build failures

## Approach
> Created a sync method in KafkaUtils using the async api from ballerina-lang

## User stories
> N/A

## Release note
> N/A

## Documentation
> N/A

## Training
> N/A
## Certification
> N/A

## Marketing
> N/A

## Automation tests
 - Unit tests 
   > Code coverage information
 - Integration tests
   > Details about the test cases and coverage

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes/no
 - Ran FindSecurityBugs plugin and verified report? yes/no
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes/no

## Samples
> N/A

## Related PRs
> https://github.com/ballerina-platform/ballerina-lang/pull/25744
## Migrations (if applicable)
> N/A

## Test environment
> JDK 8
 
## Learning
> N/A
