### PR TITLE
Migrate NonBlockingCallback to BalEnv

### DIFF
--- a/kafka-native/src/main/java/org/ballerinalang/messaging/kafka/nativeimpl/consumer/Poll.java
+++ b/kafka-native/src/main/java/org/ballerinalang/messaging/kafka/nativeimpl/consumer/Poll.java
@@ -23,6 +23,7 @@ import org.apache.kafka.clients.consumer.ConsumerRecords;
 import org.apache.kafka.clients.consumer.KafkaConsumer;
 import org.apache.kafka.common.KafkaException;
 import org.ballerinalang.jvm.api.BValueCreator;
+import org.ballerinalang.jvm.api.BalEnv;
 import org.ballerinalang.jvm.api.values.BArray;
 import org.ballerinalang.jvm.api.values.BMap;
 import org.ballerinalang.jvm.api.values.BObject;
@@ -30,7 +31,7 @@ import org.ballerinalang.jvm.api.values.BString;
 import org.ballerinalang.jvm.scheduling.Scheduler;
 import org.ballerinalang.jvm.scheduling.Strand;
 import org.ballerinalang.jvm.types.BArrayType;
-import org.ballerinalang.jvm.values.connector.NonBlockingCallback;
+import org.ballerinalang.jvm.api.BalFuture;
 import org.ballerinalang.messaging.kafka.observability.KafkaMetricsUtil;
 import org.ballerinalang.messaging.kafka.observability.KafkaObservabilityConstants;
 import org.ballerinalang.messaging.kafka.observability.KafkaTracingUtil;
@@ -59,10 +60,10 @@ public class Poll {
      * @param timeout        Duration in milliseconds to try the operation.
      * @return Ballerina {@code ConsumerRecords[]} after the polling.
      */
-    public static Object poll(BObject consumerObject, long timeout) {
+    public static Object poll(BalEnv env, BObject consumerObject, long timeout) {
         Strand strand = Scheduler.getStrand();
         KafkaTracingUtil.traceResourceInvocation(strand, consumerObject);
-        NonBlockingCallback callback = new NonBlockingCallback(strand);
+        BalFuture balFuture = env.markAsync();
         KafkaConsumer kafkaConsumer = (KafkaConsumer) consumerObject.getNativeData(NATIVE_CONSUMER);
         String keyType = consumerObject.getStringValue(CONSUMER_KEY_DESERIALIZER_TYPE_CONFIG).getValue();
         String valueType = consumerObject.getStringValue(CONSUMER_VALUE_DESERIALIZER_TYPE_CONFIG).getValue();
@@ -79,13 +80,12 @@ public class Poll {
                                                    recordValue.get(ALIAS_VALUE));
                 }
             }
-            callback.setReturnValues(consumerRecordsArray);
+            balFuture.complete(consumerRecordsArray);
         } catch (IllegalStateException | IllegalArgumentException | KafkaException e) {
             KafkaMetricsUtil.reportConsumerError(consumerObject, KafkaObservabilityConstants.ERROR_TYPE_POLL);
-            callback.notifyFailure(createKafkaError("Failed to poll from the Kafka server: " + e.getMessage(),
+            balFuture.complete(createKafkaError("Failed to poll from the Kafka server: " + e.getMessage(),
                                                     CONSUMER_ERROR));
         }
-        callback.notifySuccess();
         return null;
     }
 }

--- a/kafka-native/src/main/java/org/ballerinalang/messaging/kafka/nativeimpl/producer/SendAvroKeys.java
+++ b/kafka-native/src/main/java/org/ballerinalang/messaging/kafka/nativeimpl/producer/SendAvroKeys.java
@@ -22,6 +22,7 @@ import org.apache.avro.Schema;
 import org.apache.avro.generic.GenericData;
 import org.apache.avro.generic.GenericRecord;
 import org.apache.kafka.clients.producer.ProducerRecord;
+import org.ballerinalang.jvm.api.BalEnv;
 import org.ballerinalang.jvm.api.values.BArray;
 import org.ballerinalang.jvm.api.values.BMap;
 import org.ballerinalang.jvm.api.values.BObject;
@@ -49,7 +50,7 @@ public class SendAvroKeys {
     private static final Logger logger = LoggerFactory.getLogger(SendAvroKeys.class);
 
     // String and AvroRecord
-    public static Object sendStringValuesAvroKeys(BObject producer, BString value, BString topic,
+    public static Object sendStringValuesAvroKeys(BalEnv env, BObject producer, BString value, BString topic,
                                                   BMap<BString, Object> key, Object partition, Object timestamp) {
         GenericRecord genericRecord = createGenericRecord(key);
         Integer partitionValue = getIntValue(partition, ALIAS_PARTITION, logger);
@@ -57,33 +58,33 @@ public class SendAvroKeys {
         ProducerRecord<GenericRecord, String> kafkaRecord = new ProducerRecord<>(topic.getValue(), partitionValue,
                                                                                  timestampValue, genericRecord,
                                                                                  value.getValue());
-        return sendKafkaRecord(kafkaRecord, producer);
+        return sendKafkaRecord(env ,kafkaRecord, producer);
     }
 
     // ballerina int and AvroRecord
-    public static Object sendIntValuesAvroKeys(BObject producer, long value, BString topic,
+    public static Object sendIntValuesAvroKeys(BalEnv env, BObject producer, long value, BString topic,
                                                BMap<BString, Object> key, Object partition, Object timestamp) {
         GenericRecord genericRecord = createGenericRecord(key);
         Integer partitionValue = getIntValue(partition, ALIAS_PARTITION, logger);
         Long timestampValue = getLongValue(timestamp);
         ProducerRecord<GenericRecord, Long> kafkaRecord = new ProducerRecord<>(topic.getValue(), partitionValue,
                                                                                timestampValue, genericRecord, value);
-        return sendKafkaRecord(kafkaRecord, producer);
+        return sendKafkaRecord(env ,kafkaRecord, producer);
     }
 
     // ballerina float and AvroRecord
-    public static Object sendFloatValuesAvroKeys(BObject producer, double value, BString topic,
+    public static Object sendFloatValuesAvroKeys(BalEnv env, BObject producer, double value, BString topic,
                                                  BMap<BString, Object> key, Object partition, Object timestamp) {
         GenericRecord genericRecord = createGenericRecord(key);
         Integer partitionValue = getIntValue(partition, ALIAS_PARTITION, logger);
         Long timestampValue = getLongValue(timestamp);
         ProducerRecord<GenericRecord, Double> kafkaRecord = new ProducerRecord<>(topic.getValue(), partitionValue,
                                                                                  timestampValue, genericRecord, value);
-        return sendKafkaRecord(kafkaRecord, producer);
+        return sendKafkaRecord(env ,kafkaRecord, producer);
     }
 
     // ballerina byte[] and AvroRecord
-    public static Object sendByteArrayValuesAvroKeys(BObject producer, BArray value, BString topic,
+    public static Object sendByteArrayValuesAvroKeys(BalEnv env, BObject producer, BArray value, BString topic,
                                                      BMap<BString, Object> key, Object partition,
                                                      Object timestamp) {
         GenericRecord genericRecord = createGenericRecord(key);
@@ -92,11 +93,11 @@ public class SendAvroKeys {
         ProducerRecord<GenericRecord, byte[]> kafkaRecord = new ProducerRecord<>(topic.getValue(), partitionValue,
                                                                                  timestampValue, genericRecord,
                                                                                  value.getBytes());
-        return sendKafkaRecord(kafkaRecord, producer);
+        return sendKafkaRecord(env ,kafkaRecord, producer);
     }
 
     // ballerina AvroRecord and AvroRecord
-    public static Object sendAvroValuesAvroKeys(BObject producer, BMap<BString, Object> value, BString topic,
+    public static Object sendAvroValuesAvroKeys(BalEnv env, BObject producer, BMap<BString, Object> value, BString topic,
                                                 BMap<BString, Object> key, Object partition, Object timestamp) {
         GenericRecord valueRecord = createGenericRecord(value);
         GenericRecord keyRecord = createGenericRecord(key);
@@ -105,18 +106,18 @@ public class SendAvroKeys {
         ProducerRecord<GenericRecord, GenericRecord> kafkaRecord = new ProducerRecord<>(topic.getValue(),
                                                                                         partitionValue, timestampValue,
                                                                                         keyRecord, valueRecord);
-        return sendKafkaRecord(kafkaRecord, producer);
+        return sendKafkaRecord(env ,kafkaRecord, producer);
     }
 
     // ballerina anydata and AvroRecord
-    public static Object sendCustomValuesAvroKeys(BObject producer, Object value, BString topic,
+    public static Object sendCustomValuesAvroKeys(BalEnv env, BObject producer, Object value, BString topic,
                                                   BMap<BString, Object> key, Object partition, Object timestamp) {
         GenericRecord genericRecord = createGenericRecord(key);
         Integer partitionValue = getIntValue(partition, ALIAS_PARTITION, logger);
         Long timestampValue = getLongValue(timestamp);
         ProducerRecord<GenericRecord, Object> kafkaRecord = new ProducerRecord<>(topic.getValue(), partitionValue,
                                                                                  timestampValue, genericRecord, value);
-        return sendKafkaRecord(kafkaRecord, producer);
+        return sendKafkaRecord(env ,kafkaRecord, producer);
     }
 
     protected static GenericRecord createGenericRecord(BMap<BString, Object> value) {

--- a/kafka-native/src/main/java/org/ballerinalang/messaging/kafka/nativeimpl/producer/SendAvroValues.java
+++ b/kafka-native/src/main/java/org/ballerinalang/messaging/kafka/nativeimpl/producer/SendAvroValues.java
@@ -20,6 +20,7 @@ package org.ballerinalang.messaging.kafka.nativeimpl.producer;
 
 import org.apache.avro.generic.GenericRecord;
 import org.apache.kafka.clients.producer.ProducerRecord;
+import org.ballerinalang.jvm.api.BalEnv;
 import org.ballerinalang.jvm.api.values.BArray;
 import org.ballerinalang.jvm.api.values.BMap;
 import org.ballerinalang.jvm.api.values.BObject;
@@ -47,18 +48,18 @@ public class SendAvroValues extends Send {
 
     // ballerina AvroRecord
     @SuppressWarnings(UNCHECKED)
-    public static Object sendAvroValuesNilKeys(BObject producer, BMap<BString, Object> value, BString topic,
+    public static Object sendAvroValuesNilKeys(BalEnv env, BObject producer, BMap<BString, Object> value, BString topic,
                                                Object partition, Object timestamp) {
         GenericRecord genericRecord = createGenericRecord(value);
         Integer partitionValue = getIntValue(partition, ALIAS_PARTITION, logger);
         Long timestampValue = getLongValue(timestamp);
         ProducerRecord<?, Object> kafkaRecord = new ProducerRecord<>(topic.getValue(), partitionValue, timestampValue,
                                                                      null, genericRecord);
-        return sendKafkaRecord(kafkaRecord, producer);
+        return sendKafkaRecord(env ,kafkaRecord, producer);
     }
 
     // ballerina AvroRecord and String
-    public static Object sendAvroValuesStringKeys(BObject producer, BMap<BString, Object> value, BString topic,
+    public static Object sendAvroValuesStringKeys(BalEnv env, BObject producer, BMap<BString, Object> value, BString topic,
                                                   BString key, Object partition, Object timestamp) {
         GenericRecord genericRecord = createGenericRecord(value);
         Integer partitionValue = getIntValue(partition, ALIAS_PARTITION, logger);
@@ -66,33 +67,33 @@ public class SendAvroValues extends Send {
         ProducerRecord<String, GenericRecord> kafkaRecord = new ProducerRecord<>(topic.getValue(), partitionValue,
                                                                                  timestampValue, key.getValue(),
                                                                                  genericRecord);
-        return sendKafkaRecord(kafkaRecord, producer);
+        return sendKafkaRecord(env ,kafkaRecord, producer);
     }
 
     // ballerina AvroRecord and ballerina int
-    public static Object sendAvroValuesIntKeys(BObject producer, BMap<BString, Object> value, BString topic,
+    public static Object sendAvroValuesIntKeys(BalEnv env, BObject producer, BMap<BString, Object> value, BString topic,
                                                long key, Object partition, Object timestamp) {
         GenericRecord genericRecord = createGenericRecord(value);
         Integer partitionValue = getIntValue(partition, ALIAS_PARTITION, logger);
         Long timestampValue = getLongValue(timestamp);
         ProducerRecord<Long, GenericRecord> kafkaRecord = new ProducerRecord<>(topic.getValue(), partitionValue,
                                                                                timestampValue, key, genericRecord);
-        return sendKafkaRecord(kafkaRecord, producer);
+        return sendKafkaRecord(env ,kafkaRecord, producer);
     }
 
     // ballerina AvroRecord and ballerina float
-    public static Object sendAvroValuesFloatKeys(BObject producer, BMap<BString, Object> value, BString topic,
+    public static Object sendAvroValuesFloatKeys(BalEnv env, BObject producer, BMap<BString, Object> value, BString topic,
                                                  double key, Object partition, Object timestamp) {
         GenericRecord genericRecord = createGenericRecord(value);
         Integer partitionValue = getIntValue(partition, ALIAS_PARTITION, logger);
         Long timestampValue = getLongValue(timestamp);
         ProducerRecord<Double, GenericRecord> kafkaRecord = new ProducerRecord<>(topic.getValue(), partitionValue,
                                                                                  timestampValue, key, genericRecord);
-        return sendKafkaRecord(kafkaRecord, producer);
+        return sendKafkaRecord(env ,kafkaRecord, producer);
     }
 
     // ballerina AvroRecord and ballerina byte[]
-    public static Object sendAvroValuesByteArrayKeys(BObject producer, BMap<BString, Object> value,
+    public static Object sendAvroValuesByteArrayKeys(BalEnv env, BObject producer, BMap<BString, Object> value,
                                                      BString topic, BArray key, Object partition, Object timestamp) {
         GenericRecord genericRecord = createGenericRecord(value);
         Integer partitionValue = getIntValue(partition, ALIAS_PARTITION, logger);
@@ -100,17 +101,17 @@ public class SendAvroValues extends Send {
         ProducerRecord<byte[], GenericRecord> kafkaRecord = new ProducerRecord<>(topic.getValue(), partitionValue,
                                                                                  timestampValue, key.getBytes(),
                                                                                  genericRecord);
-        return sendKafkaRecord(kafkaRecord, producer);
+        return sendKafkaRecord(env ,kafkaRecord, producer);
     }
 
     // ballerina AvroRecord and ballerina anydata
-    public static Object sendAvroValuesCustomKeys(BObject producer, BMap<BString, Object> value, BString topic,
+    public static Object sendAvroValuesCustomKeys(BalEnv env, BObject producer, BMap<BString, Object> value, BString topic,
                                                   Object key, Object partition, Object timestamp) {
         GenericRecord genericRecord = createGenericRecord(value);
         Integer partitionValue = getIntValue(partition, ALIAS_PARTITION, logger);
         Long timestampValue = getLongValue(timestamp);
         ProducerRecord<Object, GenericRecord> kafkaRecord = new ProducerRecord<>(topic.getValue(), partitionValue,
                                                                                  timestampValue, key, genericRecord);
-        return sendKafkaRecord(kafkaRecord, producer);
+        return sendKafkaRecord(env ,kafkaRecord, producer);
     }
 }

--- a/kafka-native/src/main/java/org/ballerinalang/messaging/kafka/nativeimpl/producer/SendByteArrayValues.java
+++ b/kafka-native/src/main/java/org/ballerinalang/messaging/kafka/nativeimpl/producer/SendByteArrayValues.java
@@ -19,6 +19,7 @@
 package org.ballerinalang.messaging.kafka.nativeimpl.producer;
 
 import org.apache.kafka.clients.producer.ProducerRecord;
+import org.ballerinalang.jvm.api.BalEnv;
 import org.ballerinalang.jvm.api.values.BArray;
 import org.ballerinalang.jvm.api.values.BObject;
 import org.ballerinalang.jvm.api.values.BString;
@@ -42,64 +43,64 @@ public class SendByteArrayValues extends Send {
     private static final Logger logger = LoggerFactory.getLogger(SendByteArrayValues.class);
 
     // ballerina byte[]
-    public static Object sendByteArrayValuesNilKeys(BObject producer, BArray value, BString topic, Object partition,
+    public static Object sendByteArrayValuesNilKeys(BalEnv env, BObject producer, BArray value, BString topic, Object partition,
                                                     Object timestamp) {
         Integer partitionValue = getIntValue(partition, ALIAS_PARTITION, logger);
         Long timestampValue = getLongValue(timestamp);
         ProducerRecord<?, byte[]> kafkaRecord = new ProducerRecord<>(topic.getValue(), partitionValue, timestampValue,
                                                                      null, value.getBytes());
-        return sendKafkaRecord(kafkaRecord, producer);
+        return sendKafkaRecord(env ,kafkaRecord, producer);
     }
 
     // ballerina byte[] and String
-    public static Object sendByteArrayValuesStringKeys(BObject producer, BArray value, BString topic, BString key,
+    public static Object sendByteArrayValuesStringKeys(BalEnv env, BObject producer, BArray value, BString topic, BString key,
                                                        Object partition, Object timestamp) {
         Integer partitionValue = getIntValue(partition, ALIAS_PARTITION, logger);
         Long timestampValue = getLongValue(timestamp);
         ProducerRecord<String, byte[]> kafkaRecord = new ProducerRecord<>(topic.getValue(), partitionValue,
                                                                           timestampValue, key.getValue(),
                                                                           value.getBytes());
-        return sendKafkaRecord(kafkaRecord, producer);
+        return sendKafkaRecord(env ,kafkaRecord, producer);
     }
 
     // ballerina byte[] and ballerina int
-    public static Object sendByteArrayValuesIntKeys(BObject producer, BArray value, BString topic, long key,
+    public static Object sendByteArrayValuesIntKeys(BalEnv env, BObject producer, BArray value, BString topic, long key,
                                                     Object partition, Object timestamp) {
         Integer partitionValue = getIntValue(partition, ALIAS_PARTITION, logger);
         Long timestampValue = getLongValue(timestamp);
         ProducerRecord<Long, byte[]> kafkaRecord = new ProducerRecord<>(topic.getValue(), partitionValue,
                                                                         timestampValue, key, value.getBytes());
-        return sendKafkaRecord(kafkaRecord, producer);
+        return sendKafkaRecord(env ,kafkaRecord, producer);
     }
 
     // ballerina byte[] and ballerina float
-    public static Object sendByteArrayValuesFloatKeys(BObject producer, BArray value, BString topic, double key,
+    public static Object sendByteArrayValuesFloatKeys(BalEnv env, BObject producer, BArray value, BString topic, double key,
                                                       Object partition, Object timestamp) {
         Integer partitionValue = getIntValue(partition, ALIAS_PARTITION, logger);
         Long timestampValue = getLongValue(timestamp);
         ProducerRecord<Double, byte[]> kafkaRecord = new ProducerRecord<>(topic.getValue(), partitionValue,
                                                                           timestampValue, key, value.getBytes());
-        return sendKafkaRecord(kafkaRecord, producer);
+        return sendKafkaRecord(env ,kafkaRecord, producer);
     }
 
     // ballerina byte[] and ballerina byte[]
-    public static Object sendByteArrayValuesByteArrayKeys(BObject producer, BArray value, BString topic, BArray key,
+    public static Object sendByteArrayValuesByteArrayKeys(BalEnv env, BObject producer, BArray value, BString topic, BArray key,
                                                           Object partition, Object timestamp) {
         Integer partitionValue = getIntValue(partition, ALIAS_PARTITION, logger);
         Long timestampValue = getLongValue(timestamp);
         ProducerRecord<byte[], byte[]> kafkaRecord = new ProducerRecord<>(topic.getValue(), partitionValue,
                                                                           timestampValue, key.getBytes(),
                                                                           value.getBytes());
-        return sendKafkaRecord(kafkaRecord, producer);
+        return sendKafkaRecord(env ,kafkaRecord, producer);
     }
 
     // ballerina byte[] and ballerina anydata
-    public static Object sendByteArrayValuesCustomKeys(BObject producer, BArray value, BString topic, Object key,
+    public static Object sendByteArrayValuesCustomKeys(BalEnv env, BObject producer, BArray value, BString topic, Object key,
                                                        Object partition, Object timestamp) {
         Integer partitionValue = getIntValue(partition, ALIAS_PARTITION, logger);
         Long timestampValue = getLongValue(timestamp);
         ProducerRecord<Object, byte[]> kafkaRecord = new ProducerRecord<>(topic.getValue(), partitionValue,
                                                                           timestampValue, key, value.getBytes());
-        return sendKafkaRecord(kafkaRecord, producer);
+        return sendKafkaRecord(env ,kafkaRecord, producer);
     }
 }

--- a/kafka-native/src/main/java/org/ballerinalang/messaging/kafka/nativeimpl/producer/SendCustomValues.java
+++ b/kafka-native/src/main/java/org/ballerinalang/messaging/kafka/nativeimpl/producer/SendCustomValues.java
@@ -19,6 +19,7 @@
 package org.ballerinalang.messaging.kafka.nativeimpl.producer;
 
 import org.apache.kafka.clients.producer.ProducerRecord;
+import org.ballerinalang.jvm.api.BalEnv;
 import org.ballerinalang.jvm.api.values.BArray;
 import org.ballerinalang.jvm.api.values.BObject;
 import org.ballerinalang.jvm.api.values.BString;
@@ -42,62 +43,62 @@ public class SendCustomValues extends Send {
     private static final Logger logger = LoggerFactory.getLogger(SendCustomValues.class);
 
     // ballerina anydata
-    public static Object sendCustomValuesNilKeys(BObject producer, Object value, BString topic, Object partition,
+    public static Object sendCustomValuesNilKeys(BalEnv env, BObject producer, Object value, BString topic, Object partition,
                                                  Object timestamp) {
         Integer partitionValue = getIntValue(partition, ALIAS_PARTITION, logger);
         Long timestampValue = getLongValue(timestamp);
         ProducerRecord<?, Object> kafkaRecord = new ProducerRecord<>(topic.getValue(), partitionValue, timestampValue,
                                                                      null, value);
-        return sendKafkaRecord(kafkaRecord, producer);
+        return sendKafkaRecord(env ,kafkaRecord, producer);
     }
 
     // ballerina anydata and String
-    public static Object sendCustomValuesStringKeys(BObject producer, Object value, BString topic, BString key,
+    public static Object sendCustomValuesStringKeys(BalEnv env, BObject producer, Object value, BString topic, BString key,
                                                     Object partition, Object timestamp) {
         Integer partitionValue = getIntValue(partition, ALIAS_PARTITION, logger);
         Long timestampValue = getLongValue(timestamp);
         ProducerRecord<String, Object> kafkaRecord = new ProducerRecord<>(topic.getValue(), partitionValue,
                                                                           timestampValue, key.getValue(), value);
-        return sendKafkaRecord(kafkaRecord, producer);
+        return sendKafkaRecord(env ,kafkaRecord, producer);
     }
 
     // ballerina anydata and ballerina int
-    public static Object sendCustomValuesIntKeys(BObject producer, Object value, BString topic, long key,
+    public static Object sendCustomValuesIntKeys(BalEnv env, BObject producer, Object value, BString topic, long key,
                                                  Object partition, Object timestamp) {
         Integer partitionValue = getIntValue(partition, ALIAS_PARTITION, logger);
         Long timestampValue = getLongValue(timestamp);
         ProducerRecord<Long, Object> kafkaRecord = new ProducerRecord<>(topic.getValue(), partitionValue,
                                                                         timestampValue, key, value);
-        return sendKafkaRecord(kafkaRecord, producer);
+        return sendKafkaRecord(env ,kafkaRecord, producer);
     }
 
     // ballerina anydata and ballerina float
-    public static Object sendCustomValuesFloatKeys(BObject producer, Object value, BString topic, double key,
+    public static Object sendCustomValuesFloatKeys(BalEnv env, BObject producer, Object value, BString topic, double key,
                                                    Object partition, Object timestamp) {
         Integer partitionValue = getIntValue(partition, ALIAS_PARTITION, logger);
         Long timestampValue = getLongValue(timestamp);
         ProducerRecord<Double, Object> kafkaRecord = new ProducerRecord<>(topic.getValue(), partitionValue,
                                                                           timestampValue, key, value);
-        return sendKafkaRecord(kafkaRecord, producer);
+        return sendKafkaRecord(env ,kafkaRecord, producer);
     }
 
     // ballerina anydata and ballerina byte[]
-    public static Object sendCustomValuesByteArrayKeys(BObject producer, Object value, BString topic, BArray key,
+    public static Object sendCustomValuesByteArrayKeys(BalEnv env, BObject producer, Object value, BString topic, BArray key,
                                                        Object partition, Object timestamp) {
         Integer partitionValue = getIntValue(partition, ALIAS_PARTITION, logger);
         Long timestampValue = getLongValue(timestamp);
         ProducerRecord<byte[], Object> kafkaRecord = new ProducerRecord<>(topic.getValue(), partitionValue,
                                                                           timestampValue, key.getBytes(), value);
-        return sendKafkaRecord(kafkaRecord, producer);
+        return sendKafkaRecord(env ,kafkaRecord, producer);
     }
 
     // ballerina anydata and ballerina anydata
-    public static Object sendCustomValuesCustomKeys(BObject producer, Object value, BString topic, Object key,
+    public static Object sendCustomValuesCustomKeys(BalEnv env, BObject producer, Object value, BString topic, Object key,
                                                     Object partition, Object timestamp) {
         Integer partitionValue = getIntValue(partition, ALIAS_PARTITION, logger);
         Long timestampValue = getLongValue(timestamp);
         ProducerRecord<Object, Object> kafkaRecord = new ProducerRecord<>(topic.getValue(), partitionValue,
                                                                           timestampValue, key, value);
-        return sendKafkaRecord(kafkaRecord, producer);
+        return sendKafkaRecord(env ,kafkaRecord, producer);
     }
 }

--- a/kafka-native/src/main/java/org/ballerinalang/messaging/kafka/nativeimpl/producer/SendFloatValues.java
+++ b/kafka-native/src/main/java/org/ballerinalang/messaging/kafka/nativeimpl/producer/SendFloatValues.java
@@ -19,6 +19,7 @@
 package org.ballerinalang.messaging.kafka.nativeimpl.producer;
 
 import org.apache.kafka.clients.producer.ProducerRecord;
+import org.ballerinalang.jvm.api.BalEnv;
 import org.ballerinalang.jvm.api.values.BArray;
 import org.ballerinalang.jvm.api.values.BObject;
 import org.ballerinalang.jvm.api.values.BString;
@@ -42,62 +43,62 @@ public class SendFloatValues extends Send {
     private static final Logger logger = LoggerFactory.getLogger(SendFloatValues.class);
 
     // ballerina float and ()
-    public static Object sendFloatValuesNilKeys(BObject producer, double value, BString topic, Object partition,
+    public static Object sendFloatValuesNilKeys(BalEnv env, BObject producer, double value, BString topic, Object partition,
                                                 Object timestamp) {
         Integer partitionValue = getIntValue(partition, ALIAS_PARTITION, logger);
         Long timestampValue = getLongValue(timestamp);
         ProducerRecord<?, Double> kafkaRecord = new ProducerRecord<>(topic.getValue(), partitionValue, timestampValue,
                                                                      null, value);
-        return sendKafkaRecord(kafkaRecord, producer);
+        return sendKafkaRecord(env, kafkaRecord, producer);
     }
 
     // ballerina float and String
-    public static Object sendFloatValuesStringKeys(BObject producer, double value, BString topic, BString key,
+    public static Object sendFloatValuesStringKeys(BalEnv env, BObject producer, double value, BString topic, BString key,
                                                    Object partition, Object timestamp) {
         Integer partitionValue = getIntValue(partition, ALIAS_PARTITION, logger);
         Long timestampValue = getLongValue(timestamp);
         ProducerRecord<String, Double> kafkaRecord = new ProducerRecord<>(topic.getValue(), partitionValue,
                                                                           timestampValue, key.getValue(), value);
-        return sendKafkaRecord(kafkaRecord, producer);
+        return sendKafkaRecord(env, kafkaRecord, producer);
     }
 
     // ballerina float and ballerina int
-    public static Object sendFloatValuesIntKeys(BObject producer, double value, BString topic, long key,
+    public static Object sendFloatValuesIntKeys(BalEnv env, BObject producer, double value, BString topic, long key,
                                                 Object partition, Object timestamp) {
         Integer partitionValue = getIntValue(partition, ALIAS_PARTITION, logger);
         Long timestampValue = getLongValue(timestamp);
         ProducerRecord<Long, Double> kafkaRecord = new ProducerRecord<>(topic.getValue(), partitionValue,
                                                                         timestampValue, key, value);
-        return sendKafkaRecord(kafkaRecord, producer);
+        return sendKafkaRecord(env, kafkaRecord, producer);
     }
 
     // ballerina float and ballerina float
-    public static Object sendFloatValuesFloatKeys(BObject producer, double value, BString topic, double key,
+    public static Object sendFloatValuesFloatKeys(BalEnv env, BObject producer, double value, BString topic, double key,
                                                   Object partition, Object timestamp) {
         Integer partitionValue = getIntValue(partition, ALIAS_PARTITION, logger);
         Long timestampValue = getLongValue(timestamp);
         ProducerRecord<Double, Double> kafkaRecord = new ProducerRecord<>(topic.getValue(), partitionValue,
                                                                           timestampValue, key, value);
-        return sendKafkaRecord(kafkaRecord, producer);
+        return sendKafkaRecord(env, kafkaRecord, producer);
     }
 
     // ballerina float and ballerina byte[]
-    public static Object sendFloatValuesByteArrayKeys(BObject producer, double value, BString topic, BArray key,
+    public static Object sendFloatValuesByteArrayKeys(BalEnv env, BObject producer, double value, BString topic, BArray key,
                                                       Object partition, Object timestamp) {
         Integer partitionValue = getIntValue(partition, ALIAS_PARTITION, logger);
         Long timestampValue = getLongValue(timestamp);
         ProducerRecord<byte[], Double> kafkaRecord = new ProducerRecord<>(topic.getValue(), partitionValue,
                                                                           timestampValue, key.getBytes(), value);
-        return sendKafkaRecord(kafkaRecord, producer);
+        return sendKafkaRecord(env, kafkaRecord, producer);
     }
 
     // ballerina float and ballerina anydata
-    public static Object sendFloatValuesCustomKeys(BObject producer, double value, BString topic, Object key,
+    public static Object sendFloatValuesCustomKeys(BalEnv env, BObject producer, double value, BString topic, Object key,
                                                    Object partition, Object timestamp) {
         Integer partitionValue = getIntValue(partition, ALIAS_PARTITION, logger);
         Long timestampValue = getLongValue(timestamp);
         ProducerRecord<Object, Double> kafkaRecord = new ProducerRecord<>(topic.getValue(), partitionValue,
                                                                           timestampValue, key, value);
-        return sendKafkaRecord(kafkaRecord, producer);
+        return sendKafkaRecord(env, kafkaRecord, producer);
     }
 }

--- a/kafka-native/src/main/java/org/ballerinalang/messaging/kafka/nativeimpl/producer/SendIntValues.java
+++ b/kafka-native/src/main/java/org/ballerinalang/messaging/kafka/nativeimpl/producer/SendIntValues.java
@@ -19,6 +19,7 @@
 package org.ballerinalang.messaging.kafka.nativeimpl.producer;
 
 import org.apache.kafka.clients.producer.ProducerRecord;
+import org.ballerinalang.jvm.api.BalEnv;
 import org.ballerinalang.jvm.api.values.BArray;
 import org.ballerinalang.jvm.api.values.BObject;
 import org.ballerinalang.jvm.api.values.BString;
@@ -42,62 +43,62 @@ public class SendIntValues extends Send {
     private static final Logger logger = LoggerFactory.getLogger(SendIntValues.class);
 
     // ballerina int and ()
-    public static Object sendIntValuesNilKeys(BObject producer, long value, BString topic, Object partition,
+    public static Object sendIntValuesNilKeys(BalEnv env, BObject producer, long value, BString topic, Object partition,
                                               Object timestamp) {
         Integer partitionValue = getIntValue(partition, ALIAS_PARTITION, logger);
         Long timestampValue = getLongValue(timestamp);
         ProducerRecord<?, Long> kafkaRecord = new ProducerRecord<>(topic.getValue(), partitionValue, timestampValue,
                                                                    null, value);
-        return sendKafkaRecord(kafkaRecord, producer);
+        return sendKafkaRecord(env ,kafkaRecord, producer);
     }
 
     // ballerina int and String
-    public static Object sendIntValuesStringKeys(BObject producer, long value, BString topic, BString key,
+    public static Object sendIntValuesStringKeys(BalEnv env, BObject producer, long value, BString topic, BString key,
                                                  Object partition, Object timestamp) {
         Integer partitionValue = getIntValue(partition, ALIAS_PARTITION, logger);
         Long timestampValue = getLongValue(timestamp);
         ProducerRecord<String, Long> kafkaRecord = new ProducerRecord<>(topic.getValue(), partitionValue,
                                                                         timestampValue, key.getValue(), value);
-        return sendKafkaRecord(kafkaRecord, producer);
+        return sendKafkaRecord(env ,kafkaRecord, producer);
     }
 
     // ballerina int and ballerina int
-    public static Object sendIntValuesIntKeys(BObject producer, long value, BString topic, long key,
+    public static Object sendIntValuesIntKeys(BalEnv env, BObject producer, long value, BString topic, long key,
                                               Object partition, Object timestamp) {
         Integer partitionValue = getIntValue(partition, ALIAS_PARTITION, logger);
         Long timestampValue = getLongValue(timestamp);
         ProducerRecord<Long, Long> kafkaRecord = new ProducerRecord<>(topic.getValue(), partitionValue, timestampValue,
                                                                       key, value);
-        return sendKafkaRecord(kafkaRecord, producer);
+        return sendKafkaRecord(env ,kafkaRecord, producer);
     }
 
     // ballerina int and ballerina float
-    public static Object sendIntValuesFloatKeys(BObject producer, long value, BString topic, double key,
+    public static Object sendIntValuesFloatKeys(BalEnv env, BObject producer, long value, BString topic, double key,
                                                 Object partition, Object timestamp) {
         Integer partitionValue = getIntValue(partition, ALIAS_PARTITION, logger);
         Long timestampValue = getLongValue(timestamp);
         ProducerRecord<Double, Long> kafkaRecord = new ProducerRecord<>(topic.getValue(), partitionValue,
                                                                         timestampValue, key, value);
-        return sendKafkaRecord(kafkaRecord, producer);
+        return sendKafkaRecord(env ,kafkaRecord, producer);
     }
 
     // ballerina int and ballerina byte[]
-    public static Object sendIntValuesByteArrayKeys(BObject producer, long value, BString topic, BArray key,
+    public static Object sendIntValuesByteArrayKeys(BalEnv env, BObject producer, long value, BString topic, BArray key,
                                                     Object partition, Object timestamp) {
         Integer partitionValue = getIntValue(partition, ALIAS_PARTITION, logger);
         Long timestampValue = getLongValue(timestamp);
         ProducerRecord<byte[], Long> kafkaRecord = new ProducerRecord<>(topic.getValue(), partitionValue,
                                                                         timestampValue, key.getBytes(), value);
-        return sendKafkaRecord(kafkaRecord, producer);
+        return sendKafkaRecord(env ,kafkaRecord, producer);
     }
 
     // ballerina int and ballerina anydata
-    public static Object sendIntValuesCustomKeys(BObject producer, long value, BString topic, Object key,
+    public static Object sendIntValuesCustomKeys(BalEnv env, BObject producer, long value, BString topic, Object key,
                                                  Object partition, Object timestamp) {
         Integer partitionValue = getIntValue(partition, ALIAS_PARTITION, logger);
         Long timestampValue = getLongValue(timestamp);
         ProducerRecord<Object, Long> kafkaRecord = new ProducerRecord<>(topic.getValue(), partitionValue,
                                                                         timestampValue, key, value);
-        return sendKafkaRecord(kafkaRecord, producer);
+        return sendKafkaRecord(env ,kafkaRecord, producer);
     }
 }

--- a/kafka-native/src/main/java/org/ballerinalang/messaging/kafka/nativeimpl/producer/SendStringValues.java
+++ b/kafka-native/src/main/java/org/ballerinalang/messaging/kafka/nativeimpl/producer/SendStringValues.java
@@ -19,6 +19,7 @@
 package org.ballerinalang.messaging.kafka.nativeimpl.producer;
 
 import org.apache.kafka.clients.producer.ProducerRecord;
+import org.ballerinalang.jvm.api.BalEnv;
 import org.ballerinalang.jvm.api.values.BArray;
 import org.ballerinalang.jvm.api.values.BObject;
 import org.ballerinalang.jvm.api.values.BString;
@@ -42,64 +43,64 @@ public class SendStringValues extends Send {
     private static final Logger logger = LoggerFactory.getLogger(SendStringValues.class);
 
     // String and ()
-    public static Object sendStringValuesNilKeys(BObject producer, BString value, BString topic, Object partition,
+    public static Object sendStringValuesNilKeys(BalEnv env, BObject producer, BString value, BString topic, Object partition,
                                                  Object timestamp) {
         Integer partitionValue = getIntValue(partition, ALIAS_PARTITION, logger);
         Long timestampValue = getLongValue(timestamp);
         ProducerRecord<?, String> kafkaRecord = new ProducerRecord<>(topic.getValue(), partitionValue, timestampValue,
                                                                      null, value.getValue());
-        return sendKafkaRecord(kafkaRecord, producer);
+        return sendKafkaRecord(env ,kafkaRecord, producer);
     }
 
     // String and String
-    public static Object sendStringValuesStringKeys(BObject producer, BString value, BString topic, BString key,
+    public static Object sendStringValuesStringKeys(BalEnv env, BObject producer, BString value, BString topic, BString key,
                                                     Object partition, Object timestamp) {
         Integer partitionValue = getIntValue(partition, ALIAS_PARTITION, logger);
         Long timestampValue = getLongValue(timestamp);
         ProducerRecord<String, String> kafkaRecord = new ProducerRecord<>(topic.getValue(), partitionValue,
                                                                           timestampValue, key.getValue(),
                                                                           value.getValue());
-        return sendKafkaRecord(kafkaRecord, producer);
+        return sendKafkaRecord(env ,kafkaRecord, producer);
     }
 
     // String and ballerina int
-    public static Object sendStringValuesIntKeys(BObject producer, BString value, BString topic, long key,
+    public static Object sendStringValuesIntKeys(BalEnv env, BObject producer, BString value, BString topic, long key,
                                                  Object partition, Object timestamp) {
         Integer partitionValue = getIntValue(partition, ALIAS_PARTITION, logger);
         Long timestampValue = getLongValue(timestamp);
         ProducerRecord<Long, String> kafkaRecord = new ProducerRecord<>(topic.getValue(), partitionValue,
                                                                         timestampValue, key, value.getValue());
-        return sendKafkaRecord(kafkaRecord, producer);
+        return sendKafkaRecord(env ,kafkaRecord, producer);
     }
 
     // String and ballerina float
-    public static Object sendStringValuesFloatKeys(BObject producer, BString value, BString topic, double key,
+    public static Object sendStringValuesFloatKeys(BalEnv env, BObject producer, BString value, BString topic, double key,
                                                    Object partition, Object timestamp) {
         Integer partitionValue = getIntValue(partition, ALIAS_PARTITION, logger);
         Long timestampValue = getLongValue(timestamp);
         ProducerRecord<Double, String> kafkaRecord = new ProducerRecord<>(topic.getValue(), partitionValue,
                                                                           timestampValue, key, value.getValue());
-        return sendKafkaRecord(kafkaRecord, producer);
+        return sendKafkaRecord(env ,kafkaRecord, producer);
     }
 
     // String and ballerina byte[]
-    public static Object sendStringValuesByteArrayKeys(BObject producer, BString value, BString topic, BArray key,
+    public static Object sendStringValuesByteArrayKeys(BalEnv env, BObject producer, BString value, BString topic, BArray key,
                                                        Object partition, Object timestamp) {
         Integer partitionValue = getIntValue(partition, ALIAS_PARTITION, logger);
         Long timestampValue = getLongValue(timestamp);
         ProducerRecord<byte[], String> kafkaRecord = new ProducerRecord<>(topic.getValue(), partitionValue,
                                                                           timestampValue, key.getBytes(),
                                                                           value.getValue());
-        return sendKafkaRecord(kafkaRecord, producer);
+        return sendKafkaRecord(env ,kafkaRecord, producer);
     }
 
     // String and ballerina anydata
-    public static Object sendStringValuesCustomKeys(BObject producer, BString value, BString topic, Object key,
+    public static Object sendStringValuesCustomKeys(BalEnv env, BObject producer, BString value, BString topic, Object key,
                                                     Object partition, Object timestamp) {
         Integer partitionValue = getIntValue(partition, ALIAS_PARTITION, logger);
         Long timestampValue = getLongValue(timestamp);
         ProducerRecord<Object, String> kafkaRecord = new ProducerRecord<>(topic.getValue(), partitionValue,
                                                                           timestampValue, key, value.getValue());
-        return sendKafkaRecord(kafkaRecord, producer);
+        return sendKafkaRecord(env ,kafkaRecord, producer);
     }
 }


### PR DESCRIPTION
## Purpose
Remove deprecated API

## Goals
Replace deprecated API NonBlockingCallback with BalEnv param for interop

## Related PRs
API deprecated in - ballerina-platform/ballerina-lang#25787
Duplicate change prior to stdlib move - ballerina-platform/ballerina-lang#25854
