### PR TITLE
Change API names in producer

### DIFF
--- a/kafka-ballerina/producer.bal
+++ b/kafka-ballerina/producer.bal
@@ -52,11 +52,11 @@ public client class Producer {
 
     # Flushes the batch of records already sent to the broker by the producer.
     # ```ballerina
-    # kafka:Error? result = producer->flushRecords();
+    # kafka:Error? result = producer->'flush();
     # ```
     #
     # + return - A `kafka:Error` if records couldn't be flushed or else '()'
-    isolated remote function flushRecords() returns Error? {
+    isolated remote function 'flush() returns Error? {
         return producerFlushRecords(self);
     }
 
@@ -78,7 +78,7 @@ public client class Producer {
     #
     # + producerRecord - Record to be produced
     # + return -  A `kafka:Error` if send action fails to send data or else '()'
-    isolated remote function sendProducerRecord(ProducerRecord producerRecord) returns Error? {
+    isolated remote function send(ProducerRecord producerRecord) returns Error? {
         // Only producing byte[] values is handled at the moment
         if (self.valueSerializerType == SER_BYTE_ARRAY) {
             return sendByteArrayValues(self, producerRecord.value, producerRecord.topic, producerRecord?.key,

--- a/kafka-ballerina/tests/client_tests.bal
+++ b/kafka-ballerina/tests/client_tests.bal
@@ -197,7 +197,7 @@ function nonExistingTopicPartitionTest() returns error? {
 function producerSendStringTest() returns error? {
     Producer stringProducer = check new (producerConfiguration);
     string message = "Hello, Ballerina";
-    var result = stringProducer->sendProducerRecord({ topic: topic3, value: message.toBytes() });
+    var result = stringProducer->send({ topic: topic3, value: message.toBytes() });
     test:assertFalse(result is error, result is error ? result.toString() : result.toString());
 
     ConsumerConfiguration consumerConfiguration = {
@@ -225,11 +225,11 @@ function producerSendStringTest() returns error? {
 function producerCloseTest() returns error? {
     Producer closeTestProducer = check new (producerConfiguration);
     string message = "Test Message";
-    var result = closeTestProducer->sendProducerRecord({ topic: topic3, value: message.toBytes() });
+    var result = closeTestProducer->send({ topic: topic3, value: message.toBytes() });
     test:assertFalse(result is error, result is error ? result.toString() : result.toString());
     result = closeTestProducer->close();
     test:assertFalse(result is error, result is error ? result.toString() : result.toString());
-    result = closeTestProducer->sendProducerRecord({ topic: topic3, value: message.toBytes() });
+    result = closeTestProducer->send({ topic: topic3, value: message.toBytes() });
     test:assertTrue(result is error);
     error receivedErr = <error>result;
     string expectedErr = "Failed to send data to Kafka server: Cannot perform operation after producer has been closed";
@@ -237,7 +237,7 @@ function producerCloseTest() returns error? {
 }
 
 function sendMessage(byte[] message, string topic) returns error? {
-    return producer->sendProducerRecord({ topic: topic, value: message });
+    return producer->send({ topic: topic, value: message });
 }
 
 Service consumerService =


### PR DESCRIPTION
## Purpose
`producer->sendRecords()` is renamed to `producer->send()`
and 
`producer->flushRecords()` is renamed to `producer->flush()`