### PR TITLE
Kafka package updates for Swan Lake alpha4

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -12,6 +12,6 @@ stdlibIoVersion=0.6.0-alpha6-SNAPSHOT
 stdlibLogVersion=1.1.0-alpha6-SNAPSHOT
 stdlibRegexVersion=0.7.0-alpha6-SNAPSHOT
 stdlibTimeVersion=2.0.0-alpha6-SNAPSHOT
-stdlibTransactionVersion=1.0.9-SNAPSHOT
+stdlibTransactionVersion=1.0.10-SNAPSHOT
 stdlibUuidVersion=0.10.0-alpha6-SNAPSHOT
 stdlibCryptoVersion=1.1.0-alpha6-SNAPSHOT

--- a/kafka-ballerina/Dependencies.toml
+++ b/kafka-ballerina/Dependencies.toml
@@ -2,3 +2,8 @@
 org = "ballerina"
 name = "uuid"
 version = "@stdlib.uuid.version@"
+
+[[dependency]]
+org = "ballerina"
+name = "crypto"
+version = "@stdlib.crypto.version@"

--- a/kafka-ballerina/Package.md
+++ b/kafka-ballerina/Package.md
@@ -19,20 +19,18 @@ For examples on the usage of the operations, see the following.
 1. Initialize the Kafka message producer.
 ```ballerina
 kafka:ProducerConfiguration producerConfiguration = {
-    bootstrapServers: "localhost:9092",
     clientId: "basic-producer",
     acks: "all",
-    retryCount: 3,
-    valueSerializerType: kafka:SER_BYTE_ARRAY,
-    keySerializerType: kafka:SER_BYTE_ARRAY
+    retryCount: 3
 };
 
-kafka:Producer kafkaProducer = new (producerConfiguration);
+kafka:Producer kafkaProducer = check new (kafka:DEFAULT_URL, producerConfiguration);
 ```
 2. Use the `kafka:Producer` to publish messages. 
 ```ballerina
 string message = "Hello World, Ballerina";
-kafka:Error? result = kafkaProducer->send(message.toBytes(), "kafka-topic", key = 1);
+check kafkaProducer->send({ topic: "test-kafka-topic",
+                            value: message.toBytes() });
 ```
 
 ##### Consuming Messages
@@ -40,27 +38,24 @@ kafka:Error? result = kafkaProducer->send(message.toBytes(), "kafka-topic", key 
 1. Initializing the Kafka message consumer. 
 ```ballerina
 kafka:ConsumerConfiguration consumerConfiguration = {
-    bootstrapServers: "localhost:9092",
     groupId: "group-id",
     offsetReset: "earliest",
     topics: ["kafka-topic"]
 };
 
-kafka:Consumer consumer = new (consumerConfiguration);
+kafka:Consumer consumer = check new (kafka:DEFAULT_URL, consumerConfiguration);
 ```
 2. Use the `kafka:Consumer` as a simple record consumer.
 ```ballerina
-kafka:ConsumerRecord[]|kafka:Error result = consumer->poll(1000);
+kafka:ConsumerRecord[]|kafka:Error result = consumer->poll(1);
 ```
-3. Use the `kafka:Consumer` as a listener.
+3. Use the `kafka:Listener` as a listener.
 ```ballerina
-listener kafka:Listener lis = new (consumerConfiguration);
+listener kafka:Listener kafkaListener = new (kafka:DEFAULT_URL, consumerConfiguration);
 
-service kafkaService on lis {
-    // This resource will be executed when a message is published to the
-    // subscribed topic/topics.
-    remote function onConsumerRecord(kafka:Caler caller,
-            kafka:ConsumerRecord[] records) {
+service kafka:Service on kafkaListener {
+    remote function onConsumerRecord(kafka:Caller caller,
+                                kafka:ConsumerRecord[] records) {
     }
 }
 ```

--- a/kafka-ballerina/build.gradle
+++ b/kafka-ballerina/build.gradle
@@ -110,6 +110,7 @@ task copyPackingJarsToLib(type: Copy) {
 task updateTomlVersions {
     doLast {
         def stdlibDependentUuidVersion = project.stdlibUuidVersion.replace("-SNAPSHOT", "")
+        def stdlibDependentCryptoVersion = project.stdlibCryptoVersion.replace("-SNAPSHOT", "")
 
         def newConfig = ballerinaConfigFile.text.replace("@project.version@", project.version)
         newConfig = newConfig.replace("@toml.version@", tomlVersion)
@@ -117,6 +118,7 @@ task updateTomlVersions {
         ballerinaConfigFile.text = newConfig
 
         def newDependencyConfig = ballerinaDependencyFile.text.replace("@stdlib.uuid.version@", stdlibDependentUuidVersion)
+        newDependencyConfig = newDependencyConfig.replace("@stdlib.crypto.version@", stdlibDependentCryptoVersion)
         ballerinaDependencyFile.text = newDependencyConfig
     }
 }

--- a/kafka-ballerina/caller.bal
+++ b/kafka-ballerina/caller.bal
@@ -31,9 +31,9 @@ public client class Caller {
     # Commits given offsets and partitions for the given topics, for service.
     #
     # + offsets - Offsets to be commited
-    # + duration - Timeout duration for the commit operation execution
+    # + duration - Timeout duration (in seconds) for the commit operation execution
     # + return - `kafka:Error` if an error is encountered or else nil
-    isolated remote function commitOffset(PartitionOffset[] offsets, int duration = -1) returns Error? {
+    isolated remote function commitOffset(PartitionOffset[] offsets, decimal duration = -1) returns Error? {
         return consumerCommitOffset(self, offsets, duration);
     }
 }

--- a/kafka-ballerina/consumer.bal
+++ b/kafka-ballerina/consumer.bal
@@ -55,9 +55,9 @@ public client class Consumer {
     # kafka:Error? result = consumer->close();
     # ```
     #
-    # + duration - Timeout duration for the close operation execution
+    # + duration - Timeout duration (in seconds) for the close operation execution
     # + return - A `kafka:Error` if an error is encountered or else '()'
-    isolated remote function close(int duration = -1) returns Error? {
+    isolated remote function close(decimal duration = -1) returns Error? {
         return consumerClose(self, duration);
     }
 
@@ -73,10 +73,10 @@ public client class Consumer {
 
     # Commits given offsets and partitions for the given topics, for consumer.
     #
-    # + duration - Timeout duration for the commit operation execution
+    # + duration - Timeout duration (in seconds) for the commit operation execution
     # + offsets - Offsets to be commited
     # + return - `kafka:Error` if an error is encountered or else nil
-    isolated remote function commitOffset(PartitionOffset[] offsets, int duration = -1) returns Error? {
+    isolated remote function commitOffset(PartitionOffset[] offsets, decimal duration = -1) returns Error? {
         return consumerCommitOffset(self, offsets, duration);
     }
 
@@ -95,19 +95,19 @@ public client class Consumer {
     # string[]|kafka:Error result = consumer->getAvailableTopics();
     # ```
     #
-    # + duration - Timeout duration for the execution of the `get available topics` operation
+    # + duration - Timeout duration (in seconds) for the execution of the `get available topics` operation
     # + return - Array of topics currently available (authorized) for the consumer to subscribe or else
     #           a `kafka:Error`
-    isolated remote function getAvailableTopics(int duration = -1) returns string[]|Error {
+    isolated remote function getAvailableTopics(decimal duration = -1) returns string[]|Error {
         return consumerGetAvailableTopics(self, duration);
     }
 
     # Retrieves the start offsets for given set of partitions.
     #
     # + partitions - Array of topic partitions to get the starting offsets
-    # + duration - Timeout duration for the get beginning offsets execution
+    # + duration - Timeout duration (in seconds) for the get beginning offsets execution
     # + return - Starting offsets for the given partitions if executes successfully or else `kafka:Error`
-    isolated remote function getBeginningOffsets(TopicPartition[] partitions, int duration = -1)
+    isolated remote function getBeginningOffsets(TopicPartition[] partitions, decimal duration = -1)
     returns PartitionOffset[]|Error {
         return consumerGetBeginningOffsets(self, partitions, duration);
     }
@@ -115,10 +115,10 @@ public client class Consumer {
     # Retrieves the last committed offsets for the given topic partitions.
     #
     # + partition - The `TopicPartition` in which the committed offset is returned for consumer
-    # + duration - Timeout duration for the get committed offset operation to execute
+    # + duration - Timeout duration (in seconds) for the get committed offset operation to execute
     # + return - The last committed offset for the consumer for the given partition if there is a committed offset
     #            present, `()` if there are no committed offsets or else a `kafka:Error`
-    isolated remote function getCommittedOffset(TopicPartition partition, int duration = -1)
+    isolated remote function getCommittedOffset(TopicPartition partition, decimal duration = -1)
     returns PartitionOffset|Error? {
         return consumerGetCommittedOffset(self, partition, duration);
     }
@@ -126,9 +126,9 @@ public client class Consumer {
     # Retrieves the last offsets for given set of partitions.
     #
     # + partitions - Set of partitions to get the last offsets
-    # + duration - Timeout duration for the get end offsets operation to execute
+    # + duration - Timeout duration (in seconds) for the get end offsets operation to execute
     # + return - End offsets for the given partitions if executes successfully or else `kafka:Error`
-    isolated remote function getEndOffsets(TopicPartition[] partitions, int duration = -1)
+    isolated remote function getEndOffsets(TopicPartition[] partitions, decimal duration = -1)
     returns PartitionOffset[]|Error {
         return consumerGetEndOffsets(self, partitions, duration);
     }
@@ -147,10 +147,10 @@ public client class Consumer {
     # Retrieves the offset of the next record that will be fetched, if a records exists in that position.
     #
     # + partition - The `TopicPartition` in which the position is required
-    # + duration - Timeout duration for the get position offset operation to execute
+    # + duration - Timeout duration (in seconds) for the get position offset operation to execute
     # + return - Offset which will be fetched next (if a records exists in that offset) or else `kafka:Error` if
     #            the operation fails
-    isolated remote function getPositionOffset(TopicPartition partition, int duration = -1)
+    isolated remote function getPositionOffset(TopicPartition partition, decimal duration = -1)
     returns int|Error {
         return consumerGetPositionOffset(self, partition, duration);
     }
@@ -171,9 +171,9 @@ public client class Consumer {
     # ```
     #
     # + topic - The topic for which the partition information is needed
-    # + duration - Timeout duration for the `get topic partitions` operation to execute
+    # + duration - Timeout duration (in seconds) for the `get topic partitions` operation to execute
     # + return - Array of partitions for the given topic if executes successfully or else a `kafka:Error`
-    isolated remote function getTopicPartitions(string topic, int duration = -1)
+    isolated remote function getTopicPartitions(string topic, decimal duration = -1)
     returns TopicPartition[]|Error {
         return consumerGetTopicPartitions(self, topic, duration);
     }
@@ -191,10 +191,10 @@ public client class Consumer {
     # kafka:ConsumerRecord[]|kafka:Error result = consumer->poll(1000);
     # ```
     #
-    # + timeoutValue - Polling time in milliseconds
+    # + timeout - Polling time in seconds
     # + return - Array of consumer records if executed successfully or else a `kafka:Error`
-    isolated remote function poll(int timeoutValue) returns ConsumerRecord[]|Error {
-        return consumerPoll(self, timeoutValue);
+    isolated remote function poll(decimal timeout) returns ConsumerRecord[]|Error {
+        return consumerPoll(self, timeout);
     }
 
     # Resumes consumer retrieving messages from set of partitions which were paused earlier.

--- a/kafka-ballerina/consumer.bal
+++ b/kafka-ballerina/consumer.bal
@@ -22,12 +22,15 @@ public client class Consumer {
     public ConsumerConfiguration consumerConfig;
     private string keyDeserializerType;
     private string valueDeserializerType;
+    private string bootstrapServers;
 
     # Creates a new Kafka `Consumer`.
     #
+    # + bootstrapServers - List of remote server endpoints of kafka brokers
     # + config - Configurations related to consumer endpoint
     # + return - A `kafka:Error` if an error is encountered or else '()'
-    public isolated function init (ConsumerConfiguration config) returns Error? {
+    public isolated function init (string bootstrapServers, *ConsumerConfiguration config) returns Error? {
+        self.bootstrapServers = bootstrapServers;
         self.consumerConfig = config;
         self.keyDeserializerType = DES_BYTE_ARRAY;
         self.valueDeserializerType = DES_BYTE_ARRAY;

--- a/kafka-ballerina/consumer.bal
+++ b/kafka-ballerina/consumer.bal
@@ -22,14 +22,14 @@ public client class Consumer {
     public ConsumerConfiguration consumerConfig;
     private string keyDeserializerType;
     private string valueDeserializerType;
-    private string bootstrapServers;
+    private string|string[] bootstrapServers;
 
     # Creates a new Kafka `Consumer`.
     #
     # + bootstrapServers - List of remote server endpoints of kafka brokers
     # + config - Configurations related to consumer endpoint
     # + return - A `kafka:Error` if an error is encountered or else '()'
-    public isolated function init (string bootstrapServers, *ConsumerConfiguration config) returns Error? {
+    public isolated function init (string|string[] bootstrapServers, *ConsumerConfiguration config) returns Error? {
         self.bootstrapServers = bootstrapServers;
         self.consumerConfig = config;
         self.keyDeserializerType = DES_BYTE_ARRAY;

--- a/kafka-ballerina/consumer_utils.bal
+++ b/kafka-ballerina/consumer_utils.bal
@@ -16,7 +16,7 @@
 
 import ballerina/jballerina.java;
 
-isolated function consumerClose(Consumer consumer, int duration) returns Error? =
+isolated function consumerClose(Consumer consumer, decimal duration) returns Error? =
 @java:Method {
     name: "close",
     'class: "org.ballerinalang.messaging.kafka.nativeimpl.consumer.BrokerConnection"
@@ -46,7 +46,7 @@ isolated function consumerCommit(Consumer|Caller consumer) returns Error? =
     'class: "org.ballerinalang.messaging.kafka.nativeimpl.consumer.Commit"
 } external;
 
-isolated function consumerCommitOffset(Consumer|Caller consumer, PartitionOffset[] offsets, int duration = -1)
+isolated function consumerCommitOffset(Consumer|Caller consumer, PartitionOffset[] offsets, decimal duration = -1)
 returns Error? =
 @java:Method {
     name: "commitOffset",
@@ -65,7 +65,7 @@ isolated function consumerGetAssignment(Consumer consumer) returns TopicPartitio
     'class: "org.ballerinalang.messaging.kafka.nativeimpl.consumer.ConsumerInformationHandler"
 } external;
 
-isolated function consumerGetAvailableTopics(Consumer consumer, int duration) returns string[]|Error =
+isolated function consumerGetAvailableTopics(Consumer consumer, decimal duration) returns string[]|Error =
 @java:Method {
     name: "getAvailableTopics",
     'class: "org.ballerinalang.messaging.kafka.nativeimpl.consumer.ConsumerInformationHandler"
@@ -77,7 +77,7 @@ isolated function consumerGetPausedPartitions(Consumer consumer) returns TopicPa
     'class: "org.ballerinalang.messaging.kafka.nativeimpl.consumer.ConsumerInformationHandler"
 } external;
 
-isolated function consumerGetTopicPartitions(Consumer consumer, string topic, int duration = -1)
+isolated function consumerGetTopicPartitions(Consumer consumer, string topic, decimal duration = -1)
 returns TopicPartition[]|Error =
 @java:Method {
     name: "getTopicPartitions",
@@ -90,35 +90,35 @@ isolated function consumerGetSubscription(Consumer consumer) returns string[]|Er
     'class: "org.ballerinalang.messaging.kafka.nativeimpl.consumer.ConsumerInformationHandler"
 } external;
 
-isolated function consumerGetBeginningOffsets(Consumer consumer, TopicPartition[] partitions, int duration)
+isolated function consumerGetBeginningOffsets(Consumer consumer, TopicPartition[] partitions, decimal duration)
 returns PartitionOffset[]|Error =
 @java:Method {
     name: "getBeginningOffsets",
     'class: "org.ballerinalang.messaging.kafka.nativeimpl.consumer.GetOffsets"
 } external;
 
-isolated function consumerGetCommittedOffset(Consumer consumer, TopicPartition partition, int duration)
+isolated function consumerGetCommittedOffset(Consumer consumer, TopicPartition partition, decimal duration)
 returns PartitionOffset|Error? =
 @java:Method {
     name: "getCommittedOffset",
     'class: "org.ballerinalang.messaging.kafka.nativeimpl.consumer.GetOffsets"
 } external;
 
-isolated function consumerGetEndOffsets(Consumer consumer, TopicPartition[] partitions, int duration)
+isolated function consumerGetEndOffsets(Consumer consumer, TopicPartition[] partitions, decimal duration)
 returns PartitionOffset[]|Error =
 @java:Method {
     name: "getEndOffsets",
     'class: "org.ballerinalang.messaging.kafka.nativeimpl.consumer.GetOffsets"
 } external;
 
-isolated function consumerGetPositionOffset(Consumer consumer, TopicPartition partition, int duration = -1)
+isolated function consumerGetPositionOffset(Consumer consumer, TopicPartition partition, decimal duration = -1)
 returns int|Error =
 @java:Method {
     name: "getPositionOffset",
     'class: "org.ballerinalang.messaging.kafka.nativeimpl.consumer.GetOffsets"
 } external;
 
-isolated function consumerPoll(Consumer consumer, int timeoutValue) returns ConsumerRecord[]|Error =
+isolated function consumerPoll(Consumer consumer, decimal timeoutValue) returns ConsumerRecord[]|Error =
 @java:Method {
     name: "poll",
     'class: "org.ballerinalang.messaging.kafka.nativeimpl.consumer.Poll"

--- a/kafka-ballerina/contants.bal
+++ b/kafka-ballerina/contants.bal
@@ -24,6 +24,9 @@ const BYTE_ARRAY = "byte[]";
 const AVRO_RECORD = "kafka:AvroRecord";
 const ANY = "anydata";
 
+// default server url
+public const DEFAULT_URL = "localhost:9092";
+
 // ********************************************
 //         Consumer-Related constants         *
 // ********************************************

--- a/kafka-ballerina/listener.bal
+++ b/kafka-ballerina/listener.bal
@@ -23,14 +23,14 @@ public client class Listener {
     public ConsumerConfiguration consumerConfig;
     private string keyDeserializerType;
     private string valueDeserializerType;
-    private string bootstrapServers;
+    private string|string[] bootstrapServers;
 
     # Creates a new Kafka `Listener`.
     #
     # + bootstrapServers - List of remote server endpoints of kafka brokers
     # + config - Configurations related to consumer endpoint
     # + return - A `kafka:Error` if an error is encountered or else '()'
-    public isolated function init (string bootstrapServers, *ConsumerConfiguration config) returns Error? {
+    public isolated function init (string|string[] bootstrapServers, *ConsumerConfiguration config) returns Error? {
         self.bootstrapServers = bootstrapServers;
         self.consumerConfig = config;
         self.keyDeserializerType = DES_BYTE_ARRAY;

--- a/kafka-ballerina/listener.bal
+++ b/kafka-ballerina/listener.bal
@@ -23,12 +23,15 @@ public client class Listener {
     public ConsumerConfiguration consumerConfig;
     private string keyDeserializerType;
     private string valueDeserializerType;
+    private string bootstrapServers;
 
     # Creates a new Kafka `Listener`.
     #
+    # + bootstrapServers - List of remote server endpoints of kafka brokers
     # + config - Configurations related to consumer endpoint
     # + return - A `kafka:Error` if an error is encountered or else '()'
-    public isolated function init (ConsumerConfiguration config) returns Error? {
+    public isolated function init (string bootstrapServers, *ConsumerConfiguration config) returns Error? {
+        self.bootstrapServers = bootstrapServers;
         self.consumerConfig = config;
         self.keyDeserializerType = DES_BYTE_ARRAY;
         self.valueDeserializerType = DES_BYTE_ARRAY;

--- a/kafka-ballerina/producer.bal
+++ b/kafka-ballerina/producer.bal
@@ -25,12 +25,15 @@ public client class Producer {
     public ProducerConfiguration? producerConfig = ();
     private string keySerializerType;
     private string valueSerializerType;
+    private string bootstrapServers;
 
     # Creates a new Kafka `Producer`.
     #
+    # + bootstrapServers - List of remote server endpoints of kafka brokers
     # + config - Configurations related to initializing a Kafka `Producer`
     # + return - A `kafka:Error` if closing the producer failed or else '()'
-    public isolated function init(ProducerConfiguration config) returns Error? {
+    public isolated function init(string bootstrapServers, *ProducerConfiguration config) returns Error? {
+        self.bootstrapServers = bootstrapServers;
         self.producerConfig = config;
         self.keySerializerType = SER_BYTE_ARRAY;
         self.valueSerializerType = SER_BYTE_ARRAY;

--- a/kafka-ballerina/producer.bal
+++ b/kafka-ballerina/producer.bal
@@ -25,14 +25,14 @@ public client class Producer {
     public ProducerConfiguration? producerConfig = ();
     private string keySerializerType;
     private string valueSerializerType;
-    private string bootstrapServers;
+    private string|string[] bootstrapServers;
 
     # Creates a new Kafka `Producer`.
     #
     # + bootstrapServers - List of remote server endpoints of kafka brokers
     # + config - Configurations related to initializing a Kafka `Producer`
     # + return - A `kafka:Error` if closing the producer failed or else '()'
-    public isolated function init(string bootstrapServers, *ProducerConfiguration config) returns Error? {
+    public isolated function init(string|string[] bootstrapServers, *ProducerConfiguration config) returns Error? {
         self.bootstrapServers = bootstrapServers;
         self.producerConfig = config;
         self.keySerializerType = SER_BYTE_ARRAY;

--- a/kafka-ballerina/records.bal
+++ b/kafka-ballerina/records.bal
@@ -52,9 +52,9 @@ public type SecureSocket record {|
   |} key?;
    record {|
         Protocol name;
-        string versions?; // todo: make this string[]
+        string[] versions?;
    |} protocol;
-   string ciphers?; // todo: make this string[]
+   string[] ciphers?;
    string provider?;
 |};
 

--- a/kafka-ballerina/records.bal
+++ b/kafka-ballerina/records.bal
@@ -124,7 +124,7 @@ public type AuthenticationConfiguration record {|
 # + excludeInternalTopics - Whether records from internal topics should be exposed to the consumer
 # + decoupleProcessing - Decouples processing
 # + secureSocket - Configurations related to SSL/TLS encryption
-# + authenticationConfiguration - Authentication-related configurations for the Kafka consumer
+# + auth - Authentication-related configurations for the Kafka consumer
 # + securityProtocol - Type of the security protocol to use in the broker connection
 public type ConsumerConfiguration record {|
     string groupId?;
@@ -171,7 +171,7 @@ public type ConsumerConfiguration record {|
     boolean decoupleProcessing = false;
 
     SecureSocket secureSocket?;
-    AuthenticationConfiguration authenticationConfiguration?;
+    AuthenticationConfiguration auth?;
     SecurityProtocol securityProtocol = PROTOCOL_PLAINTEXT;
 |};
 
@@ -245,7 +245,7 @@ public type AvroGenericRecord record {
 # + transactionTimeout - Timeout (in seconds) for transaction status update from the producer
 # + enableIdempotence - Exactly one copy of each message is written to the stream when enabled
 # + secureSocket - Configurations related to SSL/TLS encryption
-# + authenticationConfiguration - Authentication-related configurations for the Kafka producer
+# + auth - Authentication-related configurations for the Kafka producer
 # + securityProtocol - Type of the security protocol to use in the broker connection
 public type ProducerConfiguration record {|
     ProducerAcks acks = ACKS_SINGLE;
@@ -283,7 +283,7 @@ public type ProducerConfiguration record {|
     boolean enableIdempotence = false;
 
     SecureSocket secureSocket?;
-    AuthenticationConfiguration authenticationConfiguration?;
+    AuthenticationConfiguration auth?;
     SecurityProtocol securityProtocol = PROTOCOL_PLAINTEXT;
 |};
 

--- a/kafka-ballerina/records.bal
+++ b/kafka-ballerina/records.bal
@@ -34,72 +34,35 @@ public type TopicPartition record {|
 |};
 
 // Security-related records
-# Configurations for facilitating secure communication with the Kafka server.
+# Configurations for secure communication with the Kafka server.
 #
-# + keyStore - Configurations associated with the KeyStore
-# + trustStore - Configurations associated with the TrustStore
-# + protocol - Configurations related to the SSL/TLS protocol and the version to be used
-# + sslProvider - The name of the security provider used for SSL connections. Default value is the default security
+# + cert - Configurations associated with `crypto:TrustStore`
+# + key - Configurations associated with `crypto:KeyStore`
+# + keyPassword - The password of the private key in the key store file. This is optional for the client
+# + protocol - SSL/TLS protocol related options
+# + ciphers - List of ciphers to be used. By default, all the available cipher suites are supported
+# + provider - Name of the security provider used for SSL connections. Default value is the default security
 #                 provider of the JVM
-# + sslKeyPassword - The password of the private key in the key store file. This is optional for the client
-# + sslCipherSuites - A list of Cipher suites. This is a named combination of the authentication, encryption, MAC, and key
-#                     exchange algorithms used to negotiate the security settings for a network connection using the TLS
-#                     or SSL network protocols. By default, all the available Cipher suites are supported
-# + sslEndpointIdentificationAlgorithm - The endpoint identification algorithm to validate the server hostname using
-#                                        the server certificate
-# + sslSecureRandomImplementation - The `SecureRandom` PRNG implementation to use for the SSL cryptography operations
 public type SecureSocket record {|
-    KeyStore keyStore;
-    TrustStore trustStore;
-    Protocols protocol;
-    string sslProvider?;
-    string sslKeyPassword?;
-    string sslCipherSuites?;
-    string sslEndpointIdentificationAlgorithm?;
-    string sslSecureRandomImplementation?;
+   crypto:TrustStore cert;
+   record {|
+        crypto:KeyStore keyStore;
+        string keyPassword?
+  |} key?;
+   record {|
+        Protocol name;
+        string versions? = []; // todo: make this string[]
+   |} protocol;
+   string ciphers?; // todo: make this string[]
+   string provider?;
 |};
 
-# Configurations related to the KeyStore.
-#
-# + keyStoreType - The file format of the KeyStore file. This is optional for the client
-# + location - The location of the KeyStore file. This is optional for the client and can be used for two-way
-#              authentication for the client
-# + password - The store password for the KeyStore file. This is optional for the client and is only needed if
-#              the `ssl.keystore.location` is configured
-# + keyManagerAlgorithm - The algorithm used by the key manager factory for SSL connections. The default value is the
-#                         key manager factory algorithm configured for the JVM
-public type KeyStore record {|
-    string keyStoreType?;
-    string location;
-    string password;
-    string keyManagerAlgorithm?;
-|};
-
-# Configurations related to the TrustStore.
-#
-# + trustStoreType - The file format of the TrustStore file
-# + location - The location of the TrustStore file
-# + password - The password for the TrustStore file. If a password is not set, access to the TrustStore is still
-#              available but integrity checking is disabled
-# + trustManagerAlgorithm - The algorithm used by the trust manager factory for SSL connections. The default value is
-#                           the trust manager factory algorithm configured for the JVM
-public type TrustStore record {|
-    string trustStoreType?;
-    string location;
-    string password;
-    string trustManagerAlgorithm?;
-|};
-
-# Configurations related to the SSL/TLS protocol and the versions to be used.
-#
-# + sslProtocol - The SSL protocol used to generate the SSLContext. The default setting is TLS, which is fine for most
-#                 cases. Allowed values in recent JVMs are TLS, TLSv1.1, and TLSv1.2. Also, SSL, SSLv2 and SSLv3 may be
-#                 supported in older JVMs but their usage is discouraged due to known security vulnerabilities
-# + sslProtocolVersions - The list of protocols enabled for SSL connections
-public type Protocols record {|
-    string sslProtocol;
-    string sslProtocolVersions;
-|};
+# Represents protocol options.
+public enum Protocol {
+   SSL,
+   TLS,
+   DTLS
+}
 
 # Configurations related to Kafka authentication mechanisms.
 #

--- a/kafka-ballerina/records.bal
+++ b/kafka-ballerina/records.bal
@@ -14,6 +14,8 @@
 // specific language governing permissions and limitations
 // under the License.
 
+import ballerina/crypto;
+
 // Common record types
 # Represents the topic partition position in which the consumed record is stored.
 #
@@ -38,7 +40,6 @@ public type TopicPartition record {|
 #
 # + cert - Configurations associated with `crypto:TrustStore`
 # + key - Configurations associated with `crypto:KeyStore`
-# + keyPassword - The password of the private key in the key store file. This is optional for the client
 # + protocol - SSL/TLS protocol related options
 # + ciphers - List of ciphers to be used. By default, all the available cipher suites are supported
 # + provider - Name of the security provider used for SSL connections. Default value is the default security
@@ -47,11 +48,11 @@ public type SecureSocket record {|
    crypto:TrustStore cert;
    record {|
         crypto:KeyStore keyStore;
-        string keyPassword?
+        string keyPassword?;
   |} key?;
    record {|
         Protocol name;
-        string versions? = []; // todo: make this string[]
+        string versions?; // todo: make this string[]
    |} protocol;
    string ciphers?; // todo: make this string[]
    string provider?;
@@ -79,7 +80,6 @@ public type AuthenticationConfiguration record {|
 // Consumer-related records
 # Configurations related to consumer endpoint.
 #
-# + bootstrapServers - List of remote server endpoints of kafka brokers
 # + groupId - Unique string that identifies the consumer
 # + topics - Topics to be subscribed by the consumer
 # + offsetReset - Offset reset strategy if no initial offset
@@ -127,7 +127,6 @@ public type AuthenticationConfiguration record {|
 # + authenticationConfiguration - Authentication-related configurations for the Kafka consumer
 # + securityProtocol - Type of the security protocol to use in the broker connection
 public type ConsumerConfiguration record {|
-    string bootstrapServers;
     string groupId?;
     string[] topics?;
     OffsetResetMethod offsetReset?;
@@ -212,7 +211,6 @@ public type AvroGenericRecord record {
 // Producer-related records
 # Represents the Kafka Producer configuration.
 #
-# + bootstrapServers - List of remote server endpoints of Kafka brokers
 # + acks - Number of acknowledgments
 # + compressionType - Compression type to be used for messages
 # + clientId - Identifier to be used for server side logging
@@ -250,7 +248,6 @@ public type AvroGenericRecord record {
 # + authenticationConfiguration - Authentication-related configurations for the Kafka producer
 # + securityProtocol - Type of the security protocol to use in the broker connection
 public type ProducerConfiguration record {|
-    string bootstrapServers;
     ProducerAcks acks = ACKS_SINGLE;
     CompressionType compressionType = COMPRESSION_NONE;
     string clientId?;

--- a/kafka-ballerina/tests/client_tests.bal
+++ b/kafka-ballerina/tests/client_tests.bal
@@ -32,26 +32,24 @@ string manualCommitTopic = "manual-commit-test-topic";
 string receivedMessage = "";
 
 ProducerConfiguration producerConfiguration = {
-    bootstrapServers: "localhost:9092",
     clientId: "basic-producer",
     acks: ACKS_ALL,
     maxBlock: 6000,
     requestTimeout: 2000,
     retryCount: 3
 };
-Producer producer = checkpanic new (producerConfiguration);
+Producer producer = checkpanic new (DEFAULT_URL, producerConfiguration);
 
 @test:Config {}
 function consumerServiceTest() returns error? {
     check sendMessage(TEST_MESSAGE.toBytes(), topic1);
     ConsumerConfiguration consumerConfiguration = {
-        bootstrapServers: "localhost:9092",
         topics: [topic1],
         offsetReset: OFFSET_RESET_EARLIEST,
         groupId: "consumer-service-test-group",
         clientId: "test-consumer-1"
     };
-    Listener consumer = check new (consumerConfiguration);
+    Listener consumer = check new (DEFAULT_URL, consumerConfiguration);
     var attachResult = check consumer.attach(consumerService);
     var startResult = check consumer.'start();
 
@@ -63,13 +61,12 @@ function consumerServiceTest() returns error? {
 function consumerFunctionsTest() returns error? {
     check sendMessage(TEST_MESSAGE.toBytes(), topic2);
     ConsumerConfiguration consumerConfiguration = {
-        bootstrapServers: "localhost:9092",
         topics: [topic2],
         offsetReset: OFFSET_RESET_EARLIEST,
         groupId: "consumer-functions-test-group",
         clientId: "test-consumer-2"
     };
-    Consumer consumer = check new (consumerConfiguration);
+    Consumer consumer = check new (DEFAULT_URL, consumerConfiguration);
     ConsumerRecord[] consumerRecords = check consumer->poll(5000);
     test:assertEquals(consumerRecords.length(), 1, "Expected: 1. Received: " + consumerRecords.length().toString());
     byte[] value = consumerRecords[0].value;
@@ -86,8 +83,7 @@ function consumerFunctionsTest() returns error? {
     dependsOn: [consumerFunctionsTest]
 }
 function consumerSubscribeUnsubscribeTest() returns error? {
-    Consumer consumer = check new ({
-        bootstrapServers: "localhost:9092",
+    Consumer consumer = check new (DEFAULT_URL, {
         groupId: "consumer-subscriber-unsubscribe-test-group",
         clientId: "test-consumer-3",
         topics: [topic1, topic2]
@@ -105,8 +101,7 @@ function consumerSubscribeUnsubscribeTest() returns error? {
     dependsOn: [consumerFunctionsTest, consumerServiceTest, producerSendStringTest, manualCommitTest]
 }
 function consumerSubscribeTest() returns error? {
-    Consumer consumer = check new ({
-        bootstrapServers: "localhost:9092",
+    Consumer consumer = check new (DEFAULT_URL, {
         groupId: "consumer-subscriber-test-group",
         clientId: "test-consumer-4",
         metadataMaxAge: 2000
@@ -125,14 +120,13 @@ function consumerSubscribeTest() returns error? {
 @test:Config {}
 function manualCommitTest() returns error? {
     ConsumerConfiguration consumerConfiguration = {
-        bootstrapServers: "localhost:9092",
         topics: [manualCommitTopic],
         offsetReset: OFFSET_RESET_EARLIEST,
         groupId: "consumer-manual-commit-test-group",
         clientId: "test-consumer-5",
         autoCommit: false
     };
-    Consumer consumer = check new(consumerConfiguration);
+    Consumer consumer = check new(DEFAULT_URL, consumerConfiguration);
     int messageCount = 10;
     int count = 0;
     while (count < messageCount) {
@@ -169,14 +163,13 @@ function manualCommitTest() returns error? {
 @test:Config {}
 function nonExistingTopicPartitionTest() returns error? {
     ConsumerConfiguration consumerConfiguration = {
-        bootstrapServers: "localhost:9092",
         topics: [manualCommitTopic],
         offsetReset: OFFSET_RESET_EARLIEST,
         groupId: "consumer-manual-commit-test-group",
         clientId: "test-consumer-6",
         autoCommit: false
     };
-    Consumer consumer = check new(consumerConfiguration);
+    Consumer consumer = check new(DEFAULT_URL, consumerConfiguration);
 
     TopicPartition nonExistingTopicPartition = {
         topic: nonExistingTopic,
@@ -195,19 +188,18 @@ function nonExistingTopicPartitionTest() returns error? {
 
 @test:Config {}
 function producerSendStringTest() returns error? {
-    Producer stringProducer = check new (producerConfiguration);
+    Producer stringProducer = check new (DEFAULT_URL, producerConfiguration);
     string message = "Hello, Ballerina";
     var result = stringProducer->send({ topic: topic3, value: message.toBytes() });
     test:assertFalse(result is error, result is error ? result.toString() : result.toString());
 
     ConsumerConfiguration consumerConfiguration = {
-        bootstrapServers: "localhost:9092",
         topics: [topic3],
         offsetReset: OFFSET_RESET_EARLIEST,
         groupId: "producer-functions-test-group",
         clientId: "test-consumer-7"
     };
-    Consumer stringConsumer = check new (consumerConfiguration);
+    Consumer stringConsumer = check new (DEFAULT_URL, consumerConfiguration);
     ConsumerRecord[] consumerRecords = check stringConsumer->poll(3000);
     test:assertEquals(consumerRecords.length(), 1);
     byte[] messageValue = consumerRecords[0].value;
@@ -223,7 +215,7 @@ function producerSendStringTest() returns error? {
     dependsOn: [producerSendStringTest]
 }
 function producerCloseTest() returns error? {
-    Producer closeTestProducer = check new (producerConfiguration);
+    Producer closeTestProducer = check new (DEFAULT_URL, producerConfiguration);
     string message = "Test Message";
     var result = closeTestProducer->send({ topic: topic3, value: message.toBytes() });
     test:assertFalse(result is error, result is error ? result.toString() : result.toString());

--- a/kafka-ballerina/tests/client_tests.bal
+++ b/kafka-ballerina/tests/client_tests.bal
@@ -34,8 +34,8 @@ string receivedMessage = "";
 ProducerConfiguration producerConfiguration = {
     clientId: "basic-producer",
     acks: ACKS_ALL,
-    maxBlock: 6000,
-    requestTimeout: 2000,
+    maxBlock: 6,
+    requestTimeout: 2,
     retryCount: 3
 };
 Producer producer = checkpanic new (DEFAULT_URL, producerConfiguration);
@@ -67,7 +67,7 @@ function consumerFunctionsTest() returns error? {
         clientId: "test-consumer-2"
     };
     Consumer consumer = check new (DEFAULT_URL, consumerConfiguration);
-    ConsumerRecord[] consumerRecords = check consumer->poll(5000);
+    ConsumerRecord[] consumerRecords = check consumer->poll(5);
     test:assertEquals(consumerRecords.length(), 1, "Expected: 1. Received: " + consumerRecords.length().toString());
     byte[] value = consumerRecords[0].value;
     string|error message = 'string:fromBytes(value);
@@ -104,14 +104,14 @@ function consumerSubscribeTest() returns error? {
     Consumer consumer = check new (DEFAULT_URL, {
         groupId: "consumer-subscriber-test-group",
         clientId: "test-consumer-4",
-        metadataMaxAge: 2000
+        metadataMaxAge: 2
     });
     string[] availableTopics = check consumer->getAvailableTopics();
     test:assertEquals(availableTopics.length(), 5);
     string[] subscribedTopics = check consumer->getSubscription();
     test:assertEquals(subscribedTopics.length(), 0);
     var result = check consumer->subscribeWithPattern("test.*");
-    var pollResult = consumer->poll(1000); // Polling to force-update the metadata
+    var pollResult = consumer->poll(1); // Polling to force-update the metadata
     string[] newSubscribedTopics = check consumer->getSubscription();
     test:assertEquals(newSubscribedTopics.length(), 3);
     var closeResult = consumer->close();
@@ -133,7 +133,7 @@ function manualCommitTest() returns error? {
         check sendMessage(count.toString().toBytes(), manualCommitTopic);
         count += 1;
     }
-    var messages = consumer->poll(1000);
+    var messages = consumer->poll(1);
     TopicPartition topicPartition = {
         topic: manualCommitTopic,
         partition: 0
@@ -200,7 +200,7 @@ function producerSendStringTest() returns error? {
         clientId: "test-consumer-7"
     };
     Consumer stringConsumer = check new (DEFAULT_URL, consumerConfiguration);
-    ConsumerRecord[] consumerRecords = check stringConsumer->poll(3000);
+    ConsumerRecord[] consumerRecords = check stringConsumer->poll(3);
     test:assertEquals(consumerRecords.length(), 1);
     byte[] messageValue = consumerRecords[0].value;
     string|error messageConverted = 'string:fromBytes(messageValue);

--- a/kafka-ballerina/types.bal
+++ b/kafka-ballerina/types.bal
@@ -27,6 +27,5 @@ public type SecurityProtocol PROTOCOL_PLAINTEXT|PROTOCOL_SASL_PLAINTEXT|PROTOCOL
 
 # The Kafka service type
 public type Service service object {
-    remote function onConsumerRecord(Caller caller, ConsumerRecord[] records);
     // To be completed when support for optional params in remote functions is available in lang
 };

--- a/kafka-native/src/main/java/org/ballerinalang/messaging/kafka/nativeimpl/consumer/BrokerConnection.java
+++ b/kafka-native/src/main/java/org/ballerinalang/messaging/kafka/nativeimpl/consumer/BrokerConnection.java
@@ -20,6 +20,7 @@ package org.ballerinalang.messaging.kafka.nativeimpl.consumer;
 
 import io.ballerina.runtime.api.Environment;
 import io.ballerina.runtime.api.values.BArray;
+import io.ballerina.runtime.api.values.BDecimal;
 import io.ballerina.runtime.api.values.BMap;
 import io.ballerina.runtime.api.values.BObject;
 import io.ballerina.runtime.api.values.BString;
@@ -51,7 +52,7 @@ import static org.ballerinalang.messaging.kafka.utils.KafkaConstants.UNCHECKED;
 import static org.ballerinalang.messaging.kafka.utils.KafkaUtils.createKafkaError;
 import static org.ballerinalang.messaging.kafka.utils.KafkaUtils.getClientIdFromProperties;
 import static org.ballerinalang.messaging.kafka.utils.KafkaUtils.getDefaultApiTimeout;
-import static org.ballerinalang.messaging.kafka.utils.KafkaUtils.getIntFromLong;
+import static org.ballerinalang.messaging.kafka.utils.KafkaUtils.getIntFromBDecimal;
 import static org.ballerinalang.messaging.kafka.utils.KafkaUtils.getTopicPartitionList;
 import static org.ballerinalang.messaging.kafka.utils.KafkaUtils.processKafkaConsumerConfig;
 
@@ -70,12 +71,12 @@ public class BrokerConnection {
      * @param duration       Duration in milliseconds to try the operation.
      * @return {@code BError}, if there's any error, null otherwise.
      */
-    public static Object close(Environment environment, BObject consumerObject, long duration) {
+    public static Object close(Environment environment, BObject consumerObject, BDecimal duration) {
         KafkaTracingUtil.traceResourceInvocation(environment, consumerObject);
         KafkaConsumer kafkaConsumer = (KafkaConsumer) consumerObject.getNativeData(NATIVE_CONSUMER);
         Properties consumerProperties = (Properties) consumerObject.getNativeData(NATIVE_CONSUMER_CONFIG);
         int defaultApiTimeout = getDefaultApiTimeout(consumerProperties);
-        int apiTimeout = getIntFromLong(duration, logger, ALIAS_DURATION);
+        int apiTimeout = getIntFromBDecimal(duration, logger, ALIAS_DURATION);
         try {
             if (apiTimeout > DURATION_UNDEFINED_VALUE) { // API timeout should given the priority over the default value
                 closeWithDuration(kafkaConsumer, apiTimeout);

--- a/kafka-native/src/main/java/org/ballerinalang/messaging/kafka/nativeimpl/consumer/BrokerConnection.java
+++ b/kafka-native/src/main/java/org/ballerinalang/messaging/kafka/nativeimpl/consumer/BrokerConnection.java
@@ -108,8 +108,9 @@ public class BrokerConnection {
                     "Kafka consumer is already connected to external broker. Please close it before re-connecting " +
                             "the external broker again.");
         }
+        BString bootStrapServers = consumerObject.getStringValue(CONSUMER_BOOTSTRAP_SERVERS_CONFIG);
         BMap<BString, Object> configs = consumerObject.getMapValue(CONSUMER_CONFIG_FIELD_NAME);
-        Properties consumerProperties = processKafkaConsumerConfig(configs);
+        Properties consumerProperties = processKafkaConsumerConfig(bootStrapServers.getValue(), configs);
         try {
             KafkaConsumer kafkaConsumer = new KafkaConsumer<>(consumerProperties);
             consumerObject.addNativeData(NATIVE_CONSUMER, kafkaConsumer);
@@ -121,7 +122,7 @@ public class BrokerConnection {
             KafkaMetricsUtil.reportConsumerError(consumerObject, KafkaObservabilityConstants.ERROR_TYPE_CONNECTION);
             return createKafkaError("Cannot connect to the kafka server: " + e.getMessage());
         }
-        console.println(KAFKA_SERVERS + configs.get(CONSUMER_BOOTSTRAP_SERVERS_CONFIG));
+        console.println(KAFKA_SERVERS + bootStrapServers.getValue());
         return null;
     }
 

--- a/kafka-native/src/main/java/org/ballerinalang/messaging/kafka/nativeimpl/consumer/BrokerConnection.java
+++ b/kafka-native/src/main/java/org/ballerinalang/messaging/kafka/nativeimpl/consumer/BrokerConnection.java
@@ -53,6 +53,7 @@ import static org.ballerinalang.messaging.kafka.utils.KafkaUtils.createKafkaErro
 import static org.ballerinalang.messaging.kafka.utils.KafkaUtils.getClientIdFromProperties;
 import static org.ballerinalang.messaging.kafka.utils.KafkaUtils.getDefaultApiTimeout;
 import static org.ballerinalang.messaging.kafka.utils.KafkaUtils.getIntFromBDecimal;
+import static org.ballerinalang.messaging.kafka.utils.KafkaUtils.getServerUrls;
 import static org.ballerinalang.messaging.kafka.utils.KafkaUtils.getTopicPartitionList;
 import static org.ballerinalang.messaging.kafka.utils.KafkaUtils.processKafkaConsumerConfig;
 
@@ -109,9 +110,9 @@ public class BrokerConnection {
                     "Kafka consumer is already connected to external broker. Please close it before re-connecting " +
                             "the external broker again.");
         }
-        BString bootStrapServers = consumerObject.getStringValue(CONSUMER_BOOTSTRAP_SERVERS_CONFIG);
+        Object bootStrapServers = consumerObject.get(CONSUMER_BOOTSTRAP_SERVERS_CONFIG);
         BMap<BString, Object> configs = consumerObject.getMapValue(CONSUMER_CONFIG_FIELD_NAME);
-        Properties consumerProperties = processKafkaConsumerConfig(bootStrapServers.getValue(), configs);
+        Properties consumerProperties = processKafkaConsumerConfig(bootStrapServers, configs);
         try {
             KafkaConsumer kafkaConsumer = new KafkaConsumer<>(consumerProperties);
             consumerObject.addNativeData(NATIVE_CONSUMER, kafkaConsumer);
@@ -123,7 +124,7 @@ public class BrokerConnection {
             KafkaMetricsUtil.reportConsumerError(consumerObject, KafkaObservabilityConstants.ERROR_TYPE_CONNECTION);
             return createKafkaError("Cannot connect to the kafka server: " + e.getMessage());
         }
-        console.println(KAFKA_SERVERS + bootStrapServers.getValue());
+        console.println(KAFKA_SERVERS + getServerUrls(bootStrapServers));
         return null;
     }
 

--- a/kafka-native/src/main/java/org/ballerinalang/messaging/kafka/nativeimpl/consumer/Commit.java
+++ b/kafka-native/src/main/java/org/ballerinalang/messaging/kafka/nativeimpl/consumer/Commit.java
@@ -20,6 +20,7 @@ package org.ballerinalang.messaging.kafka.nativeimpl.consumer;
 
 import io.ballerina.runtime.api.Environment;
 import io.ballerina.runtime.api.values.BArray;
+import io.ballerina.runtime.api.values.BDecimal;
 import io.ballerina.runtime.api.values.BObject;
 import org.apache.kafka.clients.consumer.KafkaConsumer;
 import org.apache.kafka.clients.consumer.OffsetAndMetadata;
@@ -41,7 +42,7 @@ import static org.ballerinalang.messaging.kafka.utils.KafkaConstants.NATIVE_CONS
 import static org.ballerinalang.messaging.kafka.utils.KafkaConstants.NATIVE_CONSUMER_CONFIG;
 import static org.ballerinalang.messaging.kafka.utils.KafkaUtils.createKafkaError;
 import static org.ballerinalang.messaging.kafka.utils.KafkaUtils.getDefaultApiTimeout;
-import static org.ballerinalang.messaging.kafka.utils.KafkaUtils.getIntFromLong;
+import static org.ballerinalang.messaging.kafka.utils.KafkaUtils.getIntFromBDecimal;
 import static org.ballerinalang.messaging.kafka.utils.KafkaUtils.getPartitionToMetadataMap;
 
 /**
@@ -77,13 +78,14 @@ public class Commit {
      * @param duration       Duration in milliseconds to try the operation.
      * @return {@code BError}, if there's any error, null otherwise.
      */
-    public static Object commitOffset(Environment environment, BObject consumerObject, BArray offsets, long duration) {
+    public static Object commitOffset(Environment environment, BObject consumerObject, BArray offsets,
+                                      BDecimal duration) {
         KafkaTracingUtil.traceResourceInvocation(environment, consumerObject);
         KafkaConsumer kafkaConsumer = (KafkaConsumer) consumerObject.getNativeData(NATIVE_CONSUMER);
 
         Properties consumerProperties = (Properties) consumerObject.getNativeData(NATIVE_CONSUMER_CONFIG);
         int defaultApiTimeout = getDefaultApiTimeout(consumerProperties);
-        int apiTimeout = getIntFromLong(duration, logger, ALIAS_DURATION);
+        int apiTimeout = getIntFromBDecimal(duration, logger, ALIAS_DURATION);
         Map<TopicPartition, OffsetAndMetadata> partitionToMetadataMap = getPartitionToMetadataMap(offsets);
         try {
             if (apiTimeout > DURATION_UNDEFINED_VALUE) { // API timeout should given the priority over the default value

--- a/kafka-native/src/main/java/org/ballerinalang/messaging/kafka/nativeimpl/consumer/ConsumerInformationHandler.java
+++ b/kafka-native/src/main/java/org/ballerinalang/messaging/kafka/nativeimpl/consumer/ConsumerInformationHandler.java
@@ -25,6 +25,7 @@ import io.ballerina.runtime.api.creators.ValueCreator;
 import io.ballerina.runtime.api.types.ArrayType;
 import io.ballerina.runtime.api.utils.StringUtils;
 import io.ballerina.runtime.api.values.BArray;
+import io.ballerina.runtime.api.values.BDecimal;
 import io.ballerina.runtime.api.values.BMap;
 import io.ballerina.runtime.api.values.BObject;
 import io.ballerina.runtime.api.values.BString;
@@ -52,7 +53,7 @@ import static org.ballerinalang.messaging.kafka.utils.KafkaConstants.NATIVE_CONS
 import static org.ballerinalang.messaging.kafka.utils.KafkaConstants.UNCHECKED;
 import static org.ballerinalang.messaging.kafka.utils.KafkaUtils.createKafkaError;
 import static org.ballerinalang.messaging.kafka.utils.KafkaUtils.getDefaultApiTimeout;
-import static org.ballerinalang.messaging.kafka.utils.KafkaUtils.getIntFromLong;
+import static org.ballerinalang.messaging.kafka.utils.KafkaUtils.getIntFromBDecimal;
 import static org.ballerinalang.messaging.kafka.utils.KafkaUtils.getTopicPartitionList;
 import static org.ballerinalang.messaging.kafka.utils.KafkaUtils.getTopicPartitionRecord;
 import static org.ballerinalang.messaging.kafka.utils.KafkaUtils.populateTopicPartitionRecord;
@@ -116,12 +117,12 @@ public class ConsumerInformationHandler {
      * @param duration       Duration in milliseconds to try the operation.
      * @return Array of ballerina strings, which consists of the available topics.
      */
-    public static Object getAvailableTopics(Environment environment, BObject consumerObject, long duration) {
+    public static Object getAvailableTopics(Environment environment, BObject consumerObject, BDecimal duration) {
         KafkaTracingUtil.traceResourceInvocation(environment, consumerObject);
         KafkaConsumer kafkaConsumer = (KafkaConsumer) consumerObject.getNativeData(NATIVE_CONSUMER);
         Properties consumerProperties = (Properties) consumerObject.getNativeData(NATIVE_CONSUMER_CONFIG);
         int defaultApiTimeout = getDefaultApiTimeout(consumerProperties);
-        int apiTimeout = getIntFromLong(duration, logger, ALIAS_DURATION);
+        int apiTimeout = getIntFromBDecimal(duration, logger, ALIAS_DURATION);
         Map<String, List<PartitionInfo>> topics;
         try {
             if (apiTimeout > DURATION_UNDEFINED_VALUE) {
@@ -172,13 +173,13 @@ public class ConsumerInformationHandler {
      * @return Topic partition array of the given topic.
      */
     public static Object getTopicPartitions(Environment environment, BObject consumerObject, BString topic,
-                                            long duration) {
+                                            BDecimal duration) {
         KafkaTracingUtil.traceResourceInvocation(environment, consumerObject);
         KafkaConsumer kafkaConsumer = (KafkaConsumer) consumerObject.getNativeData(NATIVE_CONSUMER);
         Properties consumerProperties = (Properties) consumerObject.getNativeData(NATIVE_CONSUMER_CONFIG);
 
         int defaultApiTimeout = getDefaultApiTimeout(consumerProperties);
-        int apiTimeout = getIntFromLong(duration, logger, ALIAS_DURATION);
+        int apiTimeout = getIntFromBDecimal(duration, logger, ALIAS_DURATION);
 
         try {
             List<PartitionInfo> partitionInfoList;

--- a/kafka-native/src/main/java/org/ballerinalang/messaging/kafka/nativeimpl/consumer/GetOffsets.java
+++ b/kafka-native/src/main/java/org/ballerinalang/messaging/kafka/nativeimpl/consumer/GetOffsets.java
@@ -20,6 +20,7 @@ package org.ballerinalang.messaging.kafka.nativeimpl.consumer;
 
 import io.ballerina.runtime.api.Environment;
 import io.ballerina.runtime.api.values.BArray;
+import io.ballerina.runtime.api.values.BDecimal;
 import io.ballerina.runtime.api.values.BMap;
 import io.ballerina.runtime.api.values.BObject;
 import io.ballerina.runtime.api.values.BString;
@@ -48,6 +49,7 @@ import static org.ballerinalang.messaging.kafka.utils.KafkaConstants.NATIVE_CONS
 import static org.ballerinalang.messaging.kafka.utils.KafkaConstants.NATIVE_CONSUMER_CONFIG;
 import static org.ballerinalang.messaging.kafka.utils.KafkaUtils.createKafkaError;
 import static org.ballerinalang.messaging.kafka.utils.KafkaUtils.getDefaultApiTimeout;
+import static org.ballerinalang.messaging.kafka.utils.KafkaUtils.getIntFromBDecimal;
 import static org.ballerinalang.messaging.kafka.utils.KafkaUtils.getIntFromLong;
 import static org.ballerinalang.messaging.kafka.utils.KafkaUtils.getPartitionOffsetArrayFromOffsetMap;
 import static org.ballerinalang.messaging.kafka.utils.KafkaUtils.getTopicPartitionList;
@@ -69,12 +71,12 @@ public class GetOffsets {
      * @return ballerina {@code PartitionOffset} array or @{BError} if an error occurred.
      */
     public static Object getBeginningOffsets(Environment environment, BObject consumerObject,
-                                             BArray topicPartitions, long duration) {
+                                             BArray topicPartitions, BDecimal duration) {
         KafkaTracingUtil.traceResourceInvocation(environment, consumerObject);
         KafkaConsumer kafkaConsumer = (KafkaConsumer) consumerObject.getNativeData(NATIVE_CONSUMER);
         Properties consumerProperties = (Properties) consumerObject.getNativeData(NATIVE_CONSUMER_CONFIG);
         int defaultApiTimeout = getDefaultApiTimeout(consumerProperties);
-        int apiTimeout = getIntFromLong(duration, logger, ALIAS_DURATION);
+        int apiTimeout = getIntFromBDecimal(duration, logger, ALIAS_DURATION);
         List<TopicPartition> partitionList = getTopicPartitionList(topicPartitions, logger);
         Map<TopicPartition, Long> offsetMap;
         try {
@@ -102,12 +104,12 @@ public class GetOffsets {
      * @return ballerina {@code PartitionOffset} value or @{BError} if an error occurred.
      */
     public static Object getCommittedOffset(Environment environment, BObject consumerObject, BMap<BString,
-            Object> topicPartition, long duration) {
+            Object> topicPartition, BDecimal duration) {
         KafkaTracingUtil.traceResourceInvocation(environment, consumerObject);
         KafkaConsumer kafkaConsumer = (KafkaConsumer) consumerObject.getNativeData(NATIVE_CONSUMER);
         Properties consumerProperties = (Properties) consumerObject.getNativeData(NATIVE_CONSUMER_CONFIG);
         int defaultApiTimeout = getDefaultApiTimeout(consumerProperties);
-        int apiTimeout = getIntFromLong(duration, logger, ALIAS_DURATION);
+        int apiTimeout = getIntFromBDecimal(duration, logger, ALIAS_DURATION);
         String topic = topicPartition.getStringValue(ALIAS_TOPIC).getValue();
         Long partition = topicPartition.getIntValue(ALIAS_PARTITION);
         TopicPartition tp = new TopicPartition(topic, getIntFromLong(partition, logger, ALIAS_PARTITION.getValue()));
@@ -143,12 +145,12 @@ public class GetOffsets {
      * @return ballerina {@code PartitionOffset} array or @{BError} if an error occurred.
      */
     public static Object getEndOffsets(Environment environment, BObject consumerObject, BArray topicPartitions,
-                                       long duration) {
+                                       BDecimal duration) {
         KafkaTracingUtil.traceResourceInvocation(environment, consumerObject);
         KafkaConsumer kafkaConsumer = (KafkaConsumer) consumerObject.getNativeData(NATIVE_CONSUMER);
         Properties consumerProperties = (Properties) consumerObject.getNativeData(NATIVE_CONSUMER_CONFIG);
         int defaultApiTimeout = getDefaultApiTimeout(consumerProperties);
-        int apiTimeout = getIntFromLong(duration, logger, ALIAS_DURATION);
+        int apiTimeout = getIntFromBDecimal(duration, logger, ALIAS_DURATION);
         ArrayList<TopicPartition> partitionList = getTopicPartitionList(topicPartitions, logger);
         Map<TopicPartition, Long> offsetMap;
 
@@ -178,12 +180,12 @@ public class GetOffsets {
      * @return ballerina {@code PartitionOffset} value or @{BError} if an error occurred.
      */
     public static Object getPositionOffset(Environment environment, BObject consumerObject, BMap<BString,
-            Object> topicPartition, long duration) {
+            Object> topicPartition, BDecimal duration) {
         KafkaTracingUtil.traceResourceInvocation(environment, consumerObject);
         KafkaConsumer kafkaConsumer = (KafkaConsumer) consumerObject.getNativeData(NATIVE_CONSUMER);
         Properties consumerProperties = (Properties) consumerObject.getNativeData(NATIVE_CONSUMER_CONFIG);
         int defaultApiTimeout = getDefaultApiTimeout(consumerProperties);
-        int apiTimeout = getIntFromLong(duration, logger, ALIAS_DURATION);
+        int apiTimeout = getIntFromBDecimal(duration, logger, ALIAS_DURATION);
         String topic = topicPartition.getStringValue(ALIAS_TOPIC).getValue();
         Long partition = topicPartition.getIntValue(ALIAS_PARTITION);
         TopicPartition tp = new TopicPartition(topic, getIntFromLong(partition, logger, ALIAS_PARTITION.getValue()));

--- a/kafka-native/src/main/java/org/ballerinalang/messaging/kafka/nativeimpl/consumer/Poll.java
+++ b/kafka-native/src/main/java/org/ballerinalang/messaging/kafka/nativeimpl/consumer/Poll.java
@@ -23,6 +23,7 @@ import io.ballerina.runtime.api.Future;
 import io.ballerina.runtime.api.creators.TypeCreator;
 import io.ballerina.runtime.api.creators.ValueCreator;
 import io.ballerina.runtime.api.values.BArray;
+import io.ballerina.runtime.api.values.BDecimal;
 import io.ballerina.runtime.api.values.BMap;
 import io.ballerina.runtime.api.values.BObject;
 import io.ballerina.runtime.api.values.BString;
@@ -40,6 +41,7 @@ import java.time.Duration;
 import static org.ballerinalang.messaging.kafka.utils.KafkaConstants.NATIVE_CONSUMER;
 import static org.ballerinalang.messaging.kafka.utils.KafkaUtils.createKafkaError;
 import static org.ballerinalang.messaging.kafka.utils.KafkaUtils.getConsumerRecord;
+import static org.ballerinalang.messaging.kafka.utils.KafkaUtils.getMilliSeconds;
 import static org.ballerinalang.messaging.kafka.utils.KafkaUtils.populateConsumerRecord;
 
 /**
@@ -54,13 +56,13 @@ public class Poll {
      * @param timeout        Duration in milliseconds to try the operation.
      * @return Ballerina {@code ConsumerRecords[]} after the polling.
      */
-    public static Object poll(Environment env, BObject consumerObject, long timeout) {
+    public static Object poll(Environment env, BObject consumerObject, BDecimal timeout) {
         KafkaTracingUtil.traceResourceInvocation(env, consumerObject);
         Future balFuture = env.markAsync();
         KafkaConsumer kafkaConsumer = (KafkaConsumer) consumerObject.getNativeData(NATIVE_CONSUMER);
         String keyType = KafkaConstants.DEFAULT_SER_DES_TYPE;
         String valueType = KafkaConstants.DEFAULT_SER_DES_TYPE;
-        Duration duration = Duration.ofMillis(timeout);
+        Duration duration = Duration.ofMillis(getMilliSeconds(timeout));
         BArray consumerRecordsArray = ValueCreator.createArrayValue(
                 TypeCreator.createArrayType(getConsumerRecord().getType()));
         try {

--- a/kafka-native/src/main/java/org/ballerinalang/messaging/kafka/nativeimpl/producer/ProducerActions.java
+++ b/kafka-native/src/main/java/org/ballerinalang/messaging/kafka/nativeimpl/producer/ProducerActions.java
@@ -49,6 +49,7 @@ import static org.ballerinalang.messaging.kafka.utils.KafkaConstants.CONSUMER_CO
 import static org.ballerinalang.messaging.kafka.utils.KafkaConstants.CONSUMER_GROUP_ID_CONFIG;
 import static org.ballerinalang.messaging.kafka.utils.KafkaConstants.NATIVE_CONSUMER;
 import static org.ballerinalang.messaging.kafka.utils.KafkaConstants.NATIVE_PRODUCER;
+import static org.ballerinalang.messaging.kafka.utils.KafkaConstants.PRODUCER_BOOTSTRAP_SERVERS_CONFIG;
 import static org.ballerinalang.messaging.kafka.utils.KafkaConstants.PRODUCER_CONFIG_FIELD_NAME;
 import static org.ballerinalang.messaging.kafka.utils.KafkaConstants.TRANSACTION_CONTEXT;
 import static org.ballerinalang.messaging.kafka.utils.KafkaUtils.createKafkaError;
@@ -72,8 +73,9 @@ public class ProducerActions {
      * @return {@code BError}, if there's any error, null otherwise.
      */
     public static Object init(BObject producerObject) {
+        BString bootstrapServer = producerObject.getStringValue(PRODUCER_BOOTSTRAP_SERVERS_CONFIG);
         BMap<BString, Object> configs = producerObject.getMapValue(PRODUCER_CONFIG_FIELD_NAME);
-        Properties producerProperties = processKafkaProducerConfig(configs);
+        Properties producerProperties = processKafkaProducerConfig(bootstrapServer.getValue(), configs);
         try {
             if (Objects.nonNull(
                     producerProperties.get(ProducerConfig.TRANSACTIONAL_ID_CONFIG))) {

--- a/kafka-native/src/main/java/org/ballerinalang/messaging/kafka/nativeimpl/producer/ProducerActions.java
+++ b/kafka-native/src/main/java/org/ballerinalang/messaging/kafka/nativeimpl/producer/ProducerActions.java
@@ -73,9 +73,9 @@ public class ProducerActions {
      * @return {@code BError}, if there's any error, null otherwise.
      */
     public static Object init(BObject producerObject) {
-        BString bootstrapServer = producerObject.getStringValue(PRODUCER_BOOTSTRAP_SERVERS_CONFIG);
+        Object bootstrapServer = producerObject.get(PRODUCER_BOOTSTRAP_SERVERS_CONFIG);
         BMap<BString, Object> configs = producerObject.getMapValue(PRODUCER_CONFIG_FIELD_NAME);
-        Properties producerProperties = processKafkaProducerConfig(bootstrapServer.getValue(), configs);
+        Properties producerProperties = processKafkaProducerConfig(bootstrapServer, configs);
         try {
             if (Objects.nonNull(
                     producerProperties.get(ProducerConfig.TRANSACTIONAL_ID_CONFIG))) {

--- a/kafka-native/src/main/java/org/ballerinalang/messaging/kafka/service/Register.java
+++ b/kafka-native/src/main/java/org/ballerinalang/messaging/kafka/service/Register.java
@@ -34,6 +34,7 @@ import org.ballerinalang.messaging.kafka.utils.KafkaUtils;
 import java.util.Objects;
 import java.util.Properties;
 
+import static org.ballerinalang.messaging.kafka.utils.KafkaConstants.CONSUMER_BOOTSTRAP_SERVERS_CONFIG;
 import static org.ballerinalang.messaging.kafka.utils.KafkaConstants.CONSUMER_CONFIG_FIELD_NAME;
 import static org.ballerinalang.messaging.kafka.utils.KafkaConstants.NATIVE_CONSUMER;
 import static org.ballerinalang.messaging.kafka.utils.KafkaConstants.SERVER_CONNECTOR;
@@ -46,8 +47,9 @@ public class Register {
 
     @SuppressWarnings(UNCHECKED)
     public static Object register(Environment env, BObject listener, BObject service, Object name) {
+        BString bootStrapServer = listener.getStringValue(CONSUMER_BOOTSTRAP_SERVERS_CONFIG);
         BMap<BString, Object> listenerConfigurations = listener.getMapValue(CONSUMER_CONFIG_FIELD_NAME);
-        Properties configs = KafkaUtils.processKafkaConsumerConfig(listenerConfigurations);
+        Properties configs = KafkaUtils.processKafkaConsumerConfig(bootStrapServer.getValue(), listenerConfigurations);
         Runtime runtime = env.getRuntime();
 
         try {

--- a/kafka-native/src/main/java/org/ballerinalang/messaging/kafka/service/Register.java
+++ b/kafka-native/src/main/java/org/ballerinalang/messaging/kafka/service/Register.java
@@ -47,9 +47,9 @@ public class Register {
 
     @SuppressWarnings(UNCHECKED)
     public static Object register(Environment env, BObject listener, BObject service, Object name) {
-        BString bootStrapServer = listener.getStringValue(CONSUMER_BOOTSTRAP_SERVERS_CONFIG);
+        Object bootStrapServer = listener.get(CONSUMER_BOOTSTRAP_SERVERS_CONFIG);
         BMap<BString, Object> listenerConfigurations = listener.getMapValue(CONSUMER_CONFIG_FIELD_NAME);
-        Properties configs = KafkaUtils.processKafkaConsumerConfig(bootStrapServer.getValue(), listenerConfigurations);
+        Properties configs = KafkaUtils.processKafkaConsumerConfig(bootStrapServer, listenerConfigurations);
         Runtime runtime = env.getRuntime();
 
         try {

--- a/kafka-native/src/main/java/org/ballerinalang/messaging/kafka/service/Stop.java
+++ b/kafka-native/src/main/java/org/ballerinalang/messaging/kafka/service/Stop.java
@@ -27,7 +27,7 @@ import java.io.PrintStream;
 
 import static org.ballerinalang.messaging.kafka.utils.KafkaConstants.SERVER_CONNECTOR;
 import static org.ballerinalang.messaging.kafka.utils.KafkaConstants.SERVICE_STOPPED;
-import static org.ballerinalang.messaging.kafka.utils.KafkaUtils.getBrokerNames;
+import static org.ballerinalang.messaging.kafka.utils.KafkaUtils.getServerUrls;
 
 /**
  * Stop the server connector.
@@ -46,7 +46,7 @@ public class Stop {
         if (!isStopped) {
             return KafkaUtils.createKafkaError("Failed to stop the kafka service.");
         }
-        console.println(SERVICE_STOPPED + getBrokerNames(listener));
+        console.println(SERVICE_STOPPED + getServerUrls(listener));
         return null;
     }
 }

--- a/kafka-native/src/main/java/org/ballerinalang/messaging/kafka/utils/KafkaConstants.java
+++ b/kafka-native/src/main/java/org/ballerinalang/messaging/kafka/utils/KafkaConstants.java
@@ -186,7 +186,7 @@ public class KafkaConstants {
     public static final BString SSL_CIPHER_SUITES_CONFIG = StringUtils.fromString("ciphers");
 
     // SASL Configuration parameters
-    public static final BString AUTHENTICATION_CONFIGURATION = StringUtils.fromString("authenticationConfiguration");
+    public static final BString AUTHENTICATION_CONFIGURATION = StringUtils.fromString("auth");
     public static final BString AUTHENTICATION_MECHANISM = StringUtils.fromString("mechanism");
     public static final BString USERNAME = StringUtils.fromString("username");
     public static final BString PASSWORD = StringUtils.fromString("password");

--- a/kafka-native/src/main/java/org/ballerinalang/messaging/kafka/utils/KafkaConstants.java
+++ b/kafka-native/src/main/java/org/ballerinalang/messaging/kafka/utils/KafkaConstants.java
@@ -172,24 +172,18 @@ public class KafkaConstants {
     // SSL Configuration parameters.
     public static final BString SECURE_SOCKET = StringUtils.fromString("secureSocket");
     public static final BString KEYSTORE_CONFIG = StringUtils.fromString("keyStore");
-    public static final BString TRUSTSTORE_CONFIG = StringUtils.fromString("trustStore");
+    public static final BString KEY_CONFIG = StringUtils.fromString("key");
+    public static final BString TRUSTSTORE_CONFIG = StringUtils.fromString("cert");
     public static final BString PROTOCOL_CONFIG = StringUtils.fromString("protocol");
-    public static final BString LOCATION_CONFIG = StringUtils.fromString("location");
+    public static final BString LOCATION_CONFIG = StringUtils.fromString("path");
     public static final BString PASSWORD_CONFIG = StringUtils.fromString("password");
-    public static final BString KEYSTORE_TYPE_CONFIG = StringUtils.fromString("keyStoreType");
-    public static final BString KEYMANAGER_ALGORITHM_CONFIG = StringUtils.fromString("keyManagerAlgorithm");
-    public static final BString TRUSTSTORE_TYPE_CONFIG = StringUtils.fromString("trustStoreType");
-    public static final BString TRUSTMANAGER_ALGORITHM_CONFIG = StringUtils.fromString("trustManagerAlgorithm");
-    public static final BString ENABLED_PROTOCOLS_CONFIG = StringUtils.fromString("sslProtocolVersions");
+    public static final BString SSL_PROTOCOL_VERSIONS = StringUtils.fromString("versions");
     public static final BString SECURITY_PROTOCOL_CONFIG = StringUtils.fromString("securityProtocol");
-    public static final BString SSL_PROTOCOL_CONFIG = StringUtils.fromString("sslProtocol");
-    public static final BString SSL_PROVIDER_CONFIG = StringUtils.fromString("sslProvider");
-    public static final BString SSL_KEY_PASSWORD_CONFIG = StringUtils.fromString("sslKeyPassword");
-    public static final BString SSL_CIPHER_SUITES_CONFIG = StringUtils.fromString("sslCipherSuites");
-    public static final BString SSL_ENDPOINT_IDENTIFICATION_ALGORITHM_CONFIG = StringUtils.fromString(
-            "sslEndpointIdentificationAlgorithm");
-    public static final BString SSL_SECURE_RANDOM_IMPLEMENTATION_CONFIG = StringUtils.fromString(
-            "sslSecureRandomImplementation");
+    public static final BString SSL_PROTOCOL_CONFIG = StringUtils.fromString("protocol");
+    public static final BString SSL_PROTOCOL_NAME = StringUtils.fromString("name");
+    public static final BString SSL_PROVIDER_CONFIG = StringUtils.fromString("provider");
+    public static final BString SSL_KEY_PASSWORD_CONFIG = StringUtils.fromString("keyPassword");
+    public static final BString SSL_CIPHER_SUITES_CONFIG = StringUtils.fromString("ciphers");
 
     // SASL Configuration parameters
     public static final BString AUTHENTICATION_CONFIGURATION = StringUtils.fromString("authenticationConfiguration");

--- a/kafka-native/src/main/java/org/ballerinalang/messaging/kafka/utils/KafkaUtils.java
+++ b/kafka-native/src/main/java/org/ballerinalang/messaging/kafka/utils/KafkaUtils.java
@@ -97,11 +97,9 @@ public class KafkaUtils {
         }
     }
 
-    public static Properties processKafkaConsumerConfig(BMap<BString, Object> configurations) {
+    public static Properties processKafkaConsumerConfig(String bootStrapServers, BMap<BString, Object> configurations) {
         Properties properties = new Properties();
-
-        addStringParamIfPresent(ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG, configurations, properties,
-                                KafkaConstants.CONSUMER_BOOTSTRAP_SERVERS_CONFIG);
+        properties.put(ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG, bootStrapServers);
         addStringParamIfPresent(ConsumerConfig.GROUP_ID_CONFIG, configurations, properties,
                                 KafkaConstants.CONSUMER_GROUP_ID_CONFIG);
         addStringParamIfPresent(ConsumerConfig.AUTO_OFFSET_RESET_CONFIG, configurations, properties,
@@ -207,10 +205,9 @@ public class KafkaUtils {
         return properties;
     }
 
-    public static Properties processKafkaProducerConfig(BMap<BString, Object> configurations) {
+    public static Properties processKafkaProducerConfig(String bootstrapServers, BMap<BString, Object> configurations) {
         Properties properties = new Properties();
-        addStringParamIfPresent(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG, configurations,
-                                properties, KafkaConstants.PRODUCER_BOOTSTRAP_SERVERS_CONFIG);
+        properties.put(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG, bootstrapServers);
         addStringParamIfPresent(ProducerConfig.ACKS_CONFIG, configurations,
                                 properties, KafkaConstants.PRODUCER_ACKS_CONFIG);
         addStringParamIfPresent(ProducerConfig.COMPRESSION_TYPE_CONFIG, configurations,
@@ -736,9 +733,9 @@ public class KafkaUtils {
     }
 
     public static String getBrokerNames(BObject listener) {
-        BMap<BString, Object> listenerConfigurations = listener.getMapValue(
-                KafkaConstants.CONSUMER_CONFIG_FIELD_NAME);
-        return listenerConfigurations.get(KafkaConstants.CONSUMER_BOOTSTRAP_SERVERS_CONFIG).toString();
+        BString bootstrapServers = listener.getStringValue(
+                KafkaConstants.CONSUMER_BOOTSTRAP_SERVERS_CONFIG);
+        return bootstrapServers.getValue();
     }
 
     public static String getTopicNamesString(List<String> topicsList) {

--- a/kafka-native/src/main/java/org/ballerinalang/messaging/kafka/utils/KafkaUtils.java
+++ b/kafka-native/src/main/java/org/ballerinalang/messaging/kafka/utils/KafkaUtils.java
@@ -191,6 +191,8 @@ public class KafkaUtils {
 
         addBooleanParamIfPresent(KafkaConstants.ALIAS_DECOUPLE_PROCESSING.getValue(), configurations, properties,
                                  KafkaConstants.ALIAS_DECOUPLE_PROCESSING, false);
+        addStringParamIfPresent(CommonClientConfigs.SECURITY_PROTOCOL_CONFIG, configurations,
+                properties, KafkaConstants.SECURITY_PROTOCOL_CONFIG);
         if (Objects.nonNull(configurations.get(KafkaConstants.SECURE_SOCKET))) {
             processSslProperties(configurations, properties);
         }
@@ -270,7 +272,8 @@ public class KafkaUtils {
                              properties, KafkaConstants.PRODUCER_CONNECTIONS_MAX_IDLE_MS_CONFIG);
         addTimeParamIfPresent(ProducerConfig.TRANSACTION_TIMEOUT_CONFIG, configurations,
                              properties, KafkaConstants.PRODUCER_TRANSACTION_TIMEOUT_CONFIG);
-
+        addStringParamIfPresent(CommonClientConfigs.SECURITY_PROTOCOL_CONFIG, configurations,
+                             properties, KafkaConstants.SECURITY_PROTOCOL_CONFIG);
         addBooleanParamIfPresent(ProducerConfig.ENABLE_IDEMPOTENCE_CONFIG, configurations,
                                  properties, KafkaConstants.PRODUCER_ENABLE_IDEMPOTENCE_CONFIG);
         if (Objects.nonNull(configurations.get(KafkaConstants.SECURE_SOCKET))) {
@@ -308,23 +311,19 @@ public class KafkaUtils {
                                 (BMap<BString, Object>) secureSocket.get(KafkaConstants.TRUSTSTORE_CONFIG),
                                 configParams, KafkaConstants.PASSWORD_CONFIG);
         // ciphers
-        addStringParamIfPresent(SslConfigs.SSL_CIPHER_SUITES_CONFIG, configurations, configParams,
-                KafkaConstants.SSL_CIPHER_SUITES_CONFIG); // todo: list
+        addStringArrayAsStringParamIfPresent(SslConfigs.SSL_CIPHER_SUITES_CONFIG, configurations, configParams,
+                KafkaConstants.SSL_CIPHER_SUITES_CONFIG);
         // provider
         addStringParamIfPresent(SslConfigs.SSL_PROVIDER_CONFIG, configurations, configParams,
                 KafkaConstants.SSL_PROVIDER_CONFIG);
-
-        addStringParamIfPresent(CommonClientConfigs.SECURITY_PROTOCOL_CONFIG,
-                                (BMap<BString, Object>) secureSocket.get(KafkaConstants.PROTOCOL_CONFIG), configParams,
-                                KafkaConstants.SECURITY_PROTOCOL_CONFIG); // todo - check
 
         // protocol
         BMap<BString, Object> protocol = (BMap<BString, Object>) secureSocket.get(KafkaConstants.PROTOCOL_CONFIG);
         addStringParamIfPresent(SslConfigs.SSL_PROTOCOL_CONFIG, protocol, configParams,
                                 KafkaConstants.SSL_PROTOCOL_NAME);
-        addStringParamIfPresent(SslConfigs.SSL_ENABLED_PROTOCOLS_CONFIG,
+        addStringArrayAsStringParamIfPresent(SslConfigs.SSL_ENABLED_PROTOCOLS_CONFIG,
                                 protocol, configParams,
-                                KafkaConstants.SSL_PROTOCOL_VERSIONS); // todo: list
+                                KafkaConstants.SSL_PROTOCOL_VERSIONS);
     }
 
     @SuppressWarnings(KafkaConstants.UNCHECKED)
@@ -448,6 +447,20 @@ public class KafkaUtils {
         BArray stringArray = (BArray) configs.get(key);
         List<String> values = getStringListFromStringBArray(stringArray);
         configParams.put(paramName, values);
+    }
+
+    private static void addStringArrayAsStringParamIfPresent(String paramName,
+                                                     BMap<BString, Object> configs,
+                                                     Properties configParams,
+                                                     BString key) {
+        BArray stringArray = (BArray) configs.get(key);
+        String values = getStringFromStringBArray(stringArray);
+        configParams.put(paramName, values);
+    }
+
+    private static String getStringFromStringBArray(BArray stringArray) {
+        String[] values = stringArray.getStringArray();
+        return String.join(",", values);
     }
 
     private static void addTimeParamIfPresent(String paramName,

--- a/kafka-native/src/main/java/org/ballerinalang/messaging/kafka/utils/KafkaUtils.java
+++ b/kafka-native/src/main/java/org/ballerinalang/messaging/kafka/utils/KafkaUtils.java
@@ -293,49 +293,41 @@ public class KafkaUtils {
     private static void processSslProperties(BMap<BString, Object> configurations, Properties configParams) {
         BMap<BString, Object> secureSocket = (BMap<BString, Object>) configurations.get(
                 KafkaConstants.SECURE_SOCKET);
-        addStringParamIfPresent(SslConfigs.SSL_KEYSTORE_TYPE_CONFIG,
-                                (BMap<BString, Object>) secureSocket.get(KafkaConstants.KEYSTORE_CONFIG), configParams,
-                                KafkaConstants.KEYSTORE_TYPE_CONFIG);
+        // keystore
+        BMap<BString, Object> keyConfig = (BMap<BString, Object>) secureSocket.get(KafkaConstants.KEY_CONFIG);
         addStringParamIfPresent(SslConfigs.SSL_KEYSTORE_LOCATION_CONFIG,
-                                (BMap<BString, Object>) secureSocket.get(KafkaConstants.KEYSTORE_CONFIG), configParams,
+                                (BMap<BString, Object>) keyConfig.get(KafkaConstants.KEYSTORE_CONFIG), configParams,
                                 KafkaConstants.LOCATION_CONFIG);
         addStringParamIfPresent(SslConfigs.SSL_KEYSTORE_PASSWORD_CONFIG,
-                                (BMap<BString, Object>) secureSocket.get(KafkaConstants.KEYSTORE_CONFIG), configParams,
+                                (BMap<BString, Object>) keyConfig.get(KafkaConstants.KEYSTORE_CONFIG), configParams,
                                 KafkaConstants.PASSWORD_CONFIG);
-        addStringParamIfPresent(SslConfigs.SSL_KEYMANAGER_ALGORITHM_CONFIG,
-                                (BMap<BString, Object>) secureSocket.get(KafkaConstants.KEYSTORE_CONFIG), configParams,
-                                KafkaConstants.KEYMANAGER_ALGORITHM_CONFIG);
-        addStringParamIfPresent(SslConfigs.SSL_TRUSTSTORE_TYPE_CONFIG,
-                                (BMap<BString, Object>) secureSocket.get(KafkaConstants.TRUSTSTORE_CONFIG),
-                                configParams, KafkaConstants.TRUSTSTORE_TYPE_CONFIG);
+        addStringParamIfPresent(SslConfigs.SSL_KEY_PASSWORD_CONFIG, keyConfig, configParams,
+                                KafkaConstants.SSL_KEY_PASSWORD_CONFIG);
+        // truststore
         addStringParamIfPresent(SslConfigs.SSL_TRUSTSTORE_LOCATION_CONFIG,
                                 (BMap<BString, Object>) secureSocket.get(KafkaConstants.TRUSTSTORE_CONFIG),
                                 configParams, KafkaConstants.LOCATION_CONFIG);
         addStringParamIfPresent(SslConfigs.SSL_TRUSTSTORE_PASSWORD_CONFIG,
                                 (BMap<BString, Object>) secureSocket.get(KafkaConstants.TRUSTSTORE_CONFIG),
                                 configParams, KafkaConstants.PASSWORD_CONFIG);
-        addStringParamIfPresent(SslConfigs.SSL_TRUSTMANAGER_ALGORITHM_CONFIG,
-                                (BMap<BString, Object>) secureSocket.get(KafkaConstants.TRUSTSTORE_CONFIG),
-                                configParams, KafkaConstants.TRUSTMANAGER_ALGORITHM_CONFIG);
+        // ciphers
+        addStringParamIfPresent(SslConfigs.SSL_CIPHER_SUITES_CONFIG, configurations, configParams,
+                KafkaConstants.SSL_CIPHER_SUITES_CONFIG); // todo: list
+        // provider
+        addStringParamIfPresent(SslConfigs.SSL_PROVIDER_CONFIG, configurations, configParams,
+                KafkaConstants.SSL_PROVIDER_CONFIG);
+
         addStringParamIfPresent(CommonClientConfigs.SECURITY_PROTOCOL_CONFIG,
                                 (BMap<BString, Object>) secureSocket.get(KafkaConstants.PROTOCOL_CONFIG), configParams,
-                                KafkaConstants.SECURITY_PROTOCOL_CONFIG);
-        addStringParamIfPresent(SslConfigs.SSL_PROTOCOL_CONFIG,
-                                (BMap<BString, Object>) secureSocket.get(KafkaConstants.PROTOCOL_CONFIG), configParams,
-                                KafkaConstants.SSL_PROTOCOL_CONFIG);
+                                KafkaConstants.SECURITY_PROTOCOL_CONFIG); // todo - check
+
+        // protocol
+        BMap<BString, Object> protocol = (BMap<BString, Object>) secureSocket.get(KafkaConstants.PROTOCOL_CONFIG);
+        addStringParamIfPresent(SslConfigs.SSL_PROTOCOL_CONFIG, protocol, configParams,
+                                KafkaConstants.SSL_PROTOCOL_NAME);
         addStringParamIfPresent(SslConfigs.SSL_ENABLED_PROTOCOLS_CONFIG,
-                                (BMap<BString, Object>) secureSocket.get(KafkaConstants.PROTOCOL_CONFIG), configParams,
-                                KafkaConstants.ENABLED_PROTOCOLS_CONFIG);
-        addStringParamIfPresent(SslConfigs.SSL_PROVIDER_CONFIG, configurations, configParams,
-                                KafkaConstants.SSL_PROVIDER_CONFIG);
-        addStringParamIfPresent(SslConfigs.SSL_KEY_PASSWORD_CONFIG, configurations, configParams,
-                                KafkaConstants.SSL_KEY_PASSWORD_CONFIG);
-        addStringParamIfPresent(SslConfigs.SSL_CIPHER_SUITES_CONFIG, configurations, configParams,
-                                KafkaConstants.SSL_CIPHER_SUITES_CONFIG);
-        addStringParamIfPresent(SslConfigs.SSL_ENDPOINT_IDENTIFICATION_ALGORITHM_CONFIG, configurations, configParams,
-                                KafkaConstants.SSL_ENDPOINT_IDENTIFICATION_ALGORITHM_CONFIG);
-        addStringParamIfPresent(SslConfigs.SSL_SECURE_RANDOM_IMPLEMENTATION_CONFIG, configurations, configParams,
-                                KafkaConstants.SSL_SECURE_RANDOM_IMPLEMENTATION_CONFIG);
+                                protocol, configParams,
+                                KafkaConstants.SSL_PROTOCOL_VERSIONS); // todo: list
     }
 
     @SuppressWarnings(KafkaConstants.UNCHECKED)

--- a/kafka-native/src/main/java/org/ballerinalang/messaging/kafka/utils/KafkaUtils.java
+++ b/kafka-native/src/main/java/org/ballerinalang/messaging/kafka/utils/KafkaUtils.java
@@ -444,18 +444,22 @@ public class KafkaUtils {
                                                      BMap<BString, Object> configs,
                                                      Properties configParams,
                                                      BString key) {
-        BArray stringArray = (BArray) configs.get(key);
-        List<String> values = getStringListFromStringBArray(stringArray);
-        configParams.put(paramName, values);
+        if (configs.containsKey(key)) {
+            BArray stringArray = (BArray) configs.get(key);
+            List<String> values = getStringListFromStringBArray(stringArray);
+            configParams.put(paramName, values);
+        }
     }
 
     private static void addStringArrayAsStringParamIfPresent(String paramName,
                                                      BMap<BString, Object> configs,
                                                      Properties configParams,
                                                      BString key) {
-        BArray stringArray = (BArray) configs.get(key);
-        String values = getStringFromStringBArray(stringArray);
-        configParams.put(paramName, values);
+        if (configs.containsKey(key)) {
+            BArray stringArray = (BArray) configs.get(key);
+            String values = getStringFromStringBArray(stringArray);
+            configParams.put(paramName, values);
+        }
     }
 
     private static String getStringFromStringBArray(BArray stringArray) {

--- a/kafka-native/src/main/java/org/ballerinalang/messaging/kafka/utils/KafkaUtils.java
+++ b/kafka-native/src/main/java/org/ballerinalang/messaging/kafka/utils/KafkaUtils.java
@@ -696,6 +696,21 @@ public class KafkaUtils {
         }
     }
 
+    public static int getIntFromBDecimal(BDecimal bDecimal, Logger logger, String name) {
+        try {
+            return  getMilliSeconds(bDecimal);
+        } catch (ArithmeticException e) {
+            logger.warn("The value set for {} needs to be less than {}. The {} value is set to {}", name,
+                    Integer.MAX_VALUE, name, Integer.MAX_VALUE);
+            return Integer.MAX_VALUE;
+        }
+    }
+
+    public static int getMilliSeconds(BDecimal longValue) {
+        BigDecimal valueInSeconds = longValue.decimalValue();
+        return  (valueInSeconds).multiply(KafkaConstants.MILLISECOND_MULTIPLIER).intValue();
+    }
+
     /**
      * Get the {@code Long} value from an {@code Object}.
      *


### PR DESCRIPTION
Fixes: https://github.com/ballerina-platform/ballerina-standard-library/issues/1170
Fixes: https://github.com/ballerina-platform/ballerina-standard-library/issues/1177

## Changes
1. SecureSocket record is changed **[Breaking]**
Design doc: https://docs.google.com/document/d/1zdRzVv4v8wDCyZcog0L31Wy17emVlM-RWUpmJ-6j3uY/edit?usp=sharing 

```ballerina
// new record
public type SecureSocket record {|
   crypto:TrustStore cert;
   record {|
        crypto:KeyStore keyStore;
        string keyPassword?
  |} key?;
   record {|
        Protocol name;
        string[] versions?;
   |} protocol?;
   string[] ciphers?; 
   string provider?;
|};

public enum Protocol {
   SSL,
   TLS,
   DTLS
}
```
2. Change producer and consumer init functions **[Breaking]**

```ballerina
// old syntax (similar for both consumer and producer)

kafka:ProducerConfiguration producerConfiguration = { |  
      bootstrapServers: "localhost:9092", 
      clientId: "basic-producer",     
      acks: "all",     
      retryCount: 3 
}; 
  
kafka:Producer kafkaProducer = check new (producerConfiguration);

// new syntax
// bootstrapServers is moved out
// kafka:ProducerConfiguration and kafka:ConsumerConfiguration are made included record parameters, 
// can give field values as named args

kafka:ProducerConfiguration producerConfiguration = { |  
      clientId: "basic-producer",     
      acks: "all",     
      retryCount: 3 
}; 
  
kafka:Producer kafkaProducer = check new (kafka:DEFAULT_URL, producerConfiguration);
```
3. Change all `duration` units to `decimal` **[Breaking]**
4. Remove onConsumerRecord function from the service definition **[Not Breaking]**
