### PR TITLE
Add Kafka compiler plugin

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -51,6 +51,10 @@ allprojects {
         }
 
         maven {
+            url = 'https://mvnrepository.com/artifact/org.testng/testng'
+        }
+
+        maven {
             url = 'https://maven.wso2.org/nexus/content/groups/wso2-public/'
         }
 
@@ -137,9 +141,15 @@ subprojects {
 
     configurations {
         ballerinaStdLibs
+        jbalTools
     }
 
     dependencies {
+        /* JBallerina Tools */
+        jbalTools ("org.ballerinalang:jballerina-tools:${ballerinaLangVersion}") {
+            transitive = false
+        }
+
         /* Standard libraries */
         ballerinaStdLibs "org.ballerinalang:file-ballerina:${stdlibFileVersion}"
         ballerinaStdLibs "org.ballerinalang:io-ballerina:${stdlibIoVersion}"

--- a/changelog.md
+++ b/changelog.md
@@ -3,6 +3,13 @@ This file contains all the notable changes done to the Ballerina Kafka package t
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.1.0-alpha8] - 2021-04-22
+
+### Added
+
+- [Add compiler plugin validations for Kafka services.](https://github.com/ballerina-platform/ballerina-standard-library/issues/1237)
+
+
 ## [2.1.0-alpha6] - 2021-04-02
 
 ### Changed

--- a/gradle.properties
+++ b/gradle.properties
@@ -6,6 +6,7 @@ ballerinaLangVersion=2.0.0-alpha8-20210408-124400-e146d512
 slf4jVersion=1.7.30
 
 puppycrawlCheckstyleVersion=8.18
+testngVersion=7.4.0
 
 stdlibFileVersion=0.7.0-alpha8-SNAPSHOT
 stdlibIoVersion=0.6.0-alpha8-SNAPSHOT

--- a/kafka-ballerina/CompilerPlugin.toml
+++ b/kafka-ballerina/CompilerPlugin.toml
@@ -1,0 +1,6 @@
+[plugin]
+id = "kafka-compiler-plugin"
+class = "io.ballerina.stdlib.kafka.plugin.KafkaCompilerPlugin"
+
+[[dependency]]
+path = "../kafka-compiler-plugin/build/libs/kafka-compiler-plugin-@project.version@.jar"

--- a/kafka-ballerina/build.gradle
+++ b/kafka-ballerina/build.gradle
@@ -25,12 +25,14 @@ def platform = "java11"
 def tomlVersion = project.version.replace("-SNAPSHOT", "")
 def ballerinaConfigFile = new File("$project.projectDir/Ballerina.toml")
 def ballerinaDependencyFile = new File("$project.projectDir/Dependencies.toml")
+def ballerinaCompilerPluginFile = new File("$project.projectDir/CompilerPlugin.toml")
 def artifactBallerinaDocs = file("$project.projectDir/build/docs_parent/")
 def artifactCacheParent = file("$project.projectDir/build/cache_parent/")
 def artifactLibParent = file("$project.projectDir/build/lib_parent/")
 def ballerinaCentralAccessToken = System.getenv('BALLERINA_CENTRAL_ACCESS_TOKEN')
 def originalConfig = ballerinaConfigFile.text
 def originalDependencies = ballerinaDependencyFile.text
+def originalCompilerPlugin = ballerinaCompilerPluginFile.text
 def distributionBinPath = project.projectDir.absolutePath + "/build/target/extracted-distributions/jballerina-tools-zip/jballerina-tools-${ballerinaLangVersion}/bin"
 
 configurations {
@@ -39,10 +41,7 @@ configurations {
 }
 
 dependencies {
-    jbalTools ("org.ballerinalang:jballerina-tools:${ballerinaLangVersion}") {
-        transitive = false
-    }
-    compile project(":${packageName}-native")
+    implementation project(":${packageName}-native")
     packingJars (group: 'org.apache.kafka', name: 'kafka-clients', version: "${kafkaVersion}") {
         transitive = false
     }
@@ -120,6 +119,9 @@ task updateTomlVersions {
         def newDependencyConfig = ballerinaDependencyFile.text.replace("@stdlib.uuid.version@", stdlibDependentUuidVersion)
         newDependencyConfig = newDependencyConfig.replace("@stdlib.crypto.version@", stdlibDependentCryptoVersion)
         ballerinaDependencyFile.text = newDependencyConfig
+
+        def newPluginConfig = ballerinaCompilerPluginFile.text.replace("@project.version@", project.version)
+        ballerinaCompilerPluginFile.text = newPluginConfig
     }
 }
 
@@ -127,6 +129,7 @@ task revertTomlFile {
     doLast {
         ballerinaConfigFile.text = originalConfig
         ballerinaDependencyFile.text = originalDependencies
+        ballerinaCompilerPluginFile.text = originalCompilerPlugin
     }
 }
 
@@ -342,6 +345,7 @@ updateTomlVersions.dependsOn copyStdlibs
 
 ballerinaTest.dependsOn startKafkaServer
 ballerinaTest.dependsOn ":${packageName}-native:build"
+ballerinaTest.dependsOn ":${packageName}-compiler-plugin:build"
 ballerinaTest.dependsOn updateTomlVersions
 ballerinaTest.dependsOn initializeVariables
 ballerinaTest.finalizedBy stopKafkaServer
@@ -350,6 +354,7 @@ test.dependsOn ballerinaTest
 
 ballerinaBuild.dependsOn updateTomlVersions
 ballerinaBuild.dependsOn ":${packageName}-native:build"
+ballerinaTest.dependsOn ":${packageName}-compiler-plugin:build"
 ballerinaBuild.dependsOn initializeVariables
 ballerinaBuild.dependsOn startKafkaServer
 ballerinaBuild.finalizedBy revertTomlFile
@@ -361,5 +366,6 @@ ballerinaPublish.dependsOn ballerinaBuild
 ballerinaPublish.dependsOn updateTomlVersions
 ballerinaPublish.dependsOn initializeVariables
 ballerinaPublish.dependsOn ":${packageName}-native:build"
+ballerinaTest.dependsOn ":${packageName}-compiler-plugin:build"
 ballerinaPublish.finalizedBy revertTomlFile
 publish.dependsOn ballerinaPublish

--- a/kafka-compiler-plugin-tests/build.gradle
+++ b/kafka-compiler-plugin-tests/build.gradle
@@ -1,0 +1,115 @@
+/*
+ * Copyright (c) 2021, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+plugins {
+    id 'java'
+    id 'checkstyle'
+    id 'com.github.spotbugs'
+}
+
+description = 'Ballerina - Kafka Compiler Plugin Tests'
+
+def ballerinaModulePath = "${project.rootDir}/kafka-ballerina/"
+def ballerinaDistPath = "${ballerinaModulePath}/build/target/extracted-distributions/jballerina-tools-zip/jballerina-tools-${ballerinaLangVersion}"
+def ballerinaDist = "${buildDir}/target/ballerina-distribution"
+
+dependencies {
+    checkstyle project(':build-config:checkstyle')
+    checkstyle "com.puppycrawl.tools:checkstyle:${puppycrawlCheckstyleVersion}"
+
+    testImplementation project(":kafka-compiler-plugin")
+    testImplementation group: 'org.ballerinalang', name: 'ballerina-lang', version: "${ballerinaLangVersion}"
+    testImplementation group: 'org.ballerinalang', name: 'ballerina-tools-api', version: "${ballerinaLangVersion}"
+    testImplementation group: 'org.ballerinalang', name: 'ballerina-parser', version: "${ballerinaLangVersion}"
+    testImplementation group: 'org.testng', name: 'testng', version: "${testngVersion}"
+}
+
+tasks.withType(Checkstyle) {
+    exclude '**/module-info.java'
+}
+
+checkstyle {
+    toolVersion "${project.puppycrawlCheckstyleVersion}"
+    configFile rootProject.file("build-config/checkstyle/build/checkstyle.xml")
+    configProperties = ["suppressionFile" : file("${rootDir}/build-config/checkstyle/build/suppressions.xml")]
+}
+
+checkstyleTest.dependsOn(":build-config:checkstyle:downloadMultipleFiles")
+
+spotbugsTest {
+    effort "max"
+    reportLevel "low"
+    reportsDir = file("$project.buildDir/reports/spotbugs")
+    reports {
+        html.enabled true
+        text.enabled = true
+    }
+    def excludeFile = file("${rootDir}/spotbugs-exclude.xml")
+    if(excludeFile.exists()) {
+        excludeFilter = excludeFile
+    }
+}
+
+spotbugsMain {
+    enabled false
+}
+
+checkstyleMain {
+    enabled false
+}
+
+compileJava {
+    doFirst {
+        options.compilerArgs = [
+                '--module-path', classpath.asPath,
+        ]
+        classpath = files()
+    }
+}
+
+task copyDistribution(type: Copy) {
+    from ballerinaDistPath
+    into ballerinaDist
+}
+
+task copyPackageBala {
+    doLast {
+        copy {
+            from "${ballerinaModulePath}/build/cache_parent"
+            into "${ballerinaDist}/repo"
+            copy {
+                into("bala/ballerina") {
+                    from "bala/ballerina"
+                }
+            }
+            copy {
+                into("cache/ballerina/") {
+                    from "cache/ballerina"
+                }
+            }
+        }
+    }
+}
+
+test {
+    useTestNG()
+}
+
+copyDistribution.dependsOn ":kafka-ballerina:build"
+copyPackageBala.dependsOn copyDistribution
+test.dependsOn copyPackageBala

--- a/kafka-compiler-plugin-tests/src/test/java/io/ballerina/stdlib/kafka/plugin/KafkaCompilerPluginTest.java
+++ b/kafka-compiler-plugin-tests/src/test/java/io/ballerina/stdlib/kafka/plugin/KafkaCompilerPluginTest.java
@@ -1,0 +1,164 @@
+/*
+ * Copyright (c) 2021, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package io.ballerina.stdlib.kafka.plugin;
+
+import io.ballerina.projects.DiagnosticResult;
+import io.ballerina.projects.Package;
+import io.ballerina.projects.PackageCompilation;
+import io.ballerina.projects.ProjectEnvironmentBuilder;
+import io.ballerina.projects.directory.BuildProject;
+import io.ballerina.projects.environment.Environment;
+import io.ballerina.projects.environment.EnvironmentBuilder;
+import io.ballerina.tools.diagnostics.Diagnostic;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+import java.nio.file.Path;
+import java.nio.file.Paths;
+
+/**
+ * Tests for Kafka package compiler plugin.
+ */
+public class KafkaCompilerPluginTest {
+    private static final Path RESOURCE_DIRECTORY = Paths.get("src", "test", "resources", "ballerina_sources")
+            .toAbsolutePath();
+    private static final Path DISTRIBUTION_PATH = Paths.get("build", "target", "ballerina-distribution")
+            .toAbsolutePath();
+
+    @Test
+    public void testValidService1() {
+        Package currentPackage = loadPackage("valid_service_1");
+        PackageCompilation compilation = currentPackage.getCompilation();
+        DiagnosticResult diagnosticResult = compilation.diagnosticResult();
+        Assert.assertEquals(diagnosticResult.diagnostics().size(), 0);
+    }
+
+    @Test
+    public void testInvalidService1() {
+        Package currentPackage = loadPackage("invalid_service_1");
+        PackageCompilation compilation = currentPackage.getCompilation();
+        DiagnosticResult diagnosticResult = compilation.diagnosticResult();
+        Assert.assertEquals(diagnosticResult.diagnostics().size(), 1);
+        Diagnostic diagnostic = (Diagnostic) diagnosticResult.diagnostics().toArray()[0];
+        assertDiagnostic(diagnostic, PluginConstants.CompilationErrors.NO_ON_CONSUMER_RECORD);
+    }
+
+    @Test
+    public void testInvalidService2() {
+        Package currentPackage = loadPackage("invalid_service_2");
+        PackageCompilation compilation = currentPackage.getCompilation();
+        DiagnosticResult diagnosticResult = compilation.diagnosticResult();
+        Assert.assertEquals(diagnosticResult.diagnostics().size(), 1);
+        Diagnostic diagnostic = (Diagnostic) diagnosticResult.diagnostics().toArray()[0];
+        assertDiagnostic(diagnostic, PluginConstants.CompilationErrors.INVALID_REMOTE_FUNCTION);
+    }
+
+    @Test
+    public void testInvalidService3() {
+        Package currentPackage = loadPackage("invalid_service_3");
+        PackageCompilation compilation = currentPackage.getCompilation();
+        DiagnosticResult diagnosticResult = compilation.diagnosticResult();
+        Assert.assertEquals(diagnosticResult.diagnostics().size(), 1);
+        Diagnostic diagnostic = (Diagnostic) diagnosticResult.diagnostics().toArray()[0];
+        assertDiagnostic(diagnostic, PluginConstants.CompilationErrors.FUNCTION_SHOULD_BE_REMOTE);
+    }
+
+    @Test
+    public void testInvalidService4() {
+        Package currentPackage = loadPackage("invalid_service_4");
+        PackageCompilation compilation = currentPackage.getCompilation();
+        DiagnosticResult diagnosticResult = compilation.diagnosticResult();
+        Assert.assertEquals(diagnosticResult.diagnostics().size(), 1);
+        Diagnostic diagnostic = (Diagnostic) diagnosticResult.diagnostics().toArray()[0];
+        assertDiagnostic(diagnostic, PluginConstants.CompilationErrors.ONLY_PARAMS_ALLOWED);
+    }
+
+    @Test
+    public void testInvalidService5() {
+        Package currentPackage = loadPackage("invalid_service_5");
+        PackageCompilation compilation = currentPackage.getCompilation();
+        DiagnosticResult diagnosticResult = compilation.diagnosticResult();
+        Assert.assertEquals(diagnosticResult.diagnostics().size(), 2);
+        Object[] diagnostics = diagnosticResult.diagnostics().toArray();
+        for (Object obj : diagnostics) {
+            Diagnostic diagnostic = (Diagnostic) obj;
+            assertDiagnostic(diagnostic, PluginConstants.CompilationErrors.INVALID_FUNCTION_PARAM_CALLER);
+        }
+    }
+
+    @Test
+    public void testInvalidService6() {
+        Package currentPackage = loadPackage("invalid_service_6");
+        PackageCompilation compilation = currentPackage.getCompilation();
+        DiagnosticResult diagnosticResult = compilation.diagnosticResult();
+        Assert.assertEquals(diagnosticResult.diagnostics().size(), 1);
+        Diagnostic diagnostic = (Diagnostic) diagnosticResult.diagnostics().toArray()[0];
+        assertDiagnostic(diagnostic, PluginConstants.CompilationErrors.INVALID_RETURN_TYPE_ERROR_OR_NIL);
+    }
+
+    @Test
+    public void testInvalidService7() {
+        Package currentPackage = loadPackage("invalid_service_7");
+        PackageCompilation compilation = currentPackage.getCompilation();
+        DiagnosticResult diagnosticResult = compilation.diagnosticResult();
+        Assert.assertEquals(diagnosticResult.diagnostics().size(), 1);
+        Diagnostic diagnostic = (Diagnostic) diagnosticResult.diagnostics().toArray()[0];
+        assertDiagnostic(diagnostic, PluginConstants.CompilationErrors.MUST_HAVE_CALLER_AND_RECORDS);
+    }
+
+    @Test
+    public void testInvalidService8() {
+        Package currentPackage = loadPackage("invalid_service_8");
+        PackageCompilation compilation = currentPackage.getCompilation();
+        DiagnosticResult diagnosticResult = compilation.diagnosticResult();
+        Assert.assertEquals(diagnosticResult.diagnostics().size(), 3);
+        Object[] diagnostics = diagnosticResult.diagnostics().toArray();
+        for (Object obj : diagnostics) {
+            Diagnostic diagnostic = (Diagnostic) obj;
+            assertDiagnostic(diagnostic, PluginConstants.CompilationErrors.INVALID_FUNCTION_PARAM_RECORDS);
+        }
+    }
+
+    @Test
+    public void testInvalidService9() {
+        Package currentPackage = loadPackage("invalid_service_9");
+        PackageCompilation compilation = currentPackage.getCompilation();
+        DiagnosticResult diagnosticResult = compilation.diagnosticResult();
+        Assert.assertEquals(diagnosticResult.diagnostics().size(), 1);
+        Diagnostic diagnostic = (Diagnostic) diagnosticResult.diagnostics().toArray()[0];
+        assertDiagnostic(diagnostic, PluginConstants.CompilationErrors.INVALID_MULTIPLE_LISTENERS);
+    }
+
+    private Package loadPackage(String path) {
+        Path projectDirPath = RESOURCE_DIRECTORY.resolve(path);
+        BuildProject project = BuildProject.load(getEnvironmentBuilder(), projectDirPath);
+        return project.currentPackage();
+    }
+
+    private static ProjectEnvironmentBuilder getEnvironmentBuilder() {
+        Environment environment = EnvironmentBuilder.getBuilder().setBallerinaHome(DISTRIBUTION_PATH).build();
+        return ProjectEnvironmentBuilder.getBuilder(environment);
+    }
+
+    private void assertDiagnostic(Diagnostic diagnostic, PluginConstants.CompilationErrors error) {
+        Assert.assertEquals(diagnostic.diagnosticInfo().code(), error.getErrorCode());
+        Assert.assertEquals(diagnostic.diagnosticInfo().messageFormat(),
+                error.getError());
+    }
+}

--- a/kafka-compiler-plugin-tests/src/test/java/io/ballerina/stdlib/kafka/plugin/KafkaCompilerPluginTest.java
+++ b/kafka-compiler-plugin-tests/src/test/java/io/ballerina/stdlib/kafka/plugin/KafkaCompilerPluginTest.java
@@ -50,6 +50,14 @@ public class KafkaCompilerPluginTest {
     }
 
     @Test
+    public void testValidService2() {
+        Package currentPackage = loadPackage("valid_service_2");
+        PackageCompilation compilation = currentPackage.getCompilation();
+        DiagnosticResult diagnosticResult = compilation.diagnosticResult();
+        Assert.assertEquals(diagnosticResult.diagnostics().size(), 0);
+    }
+
+    @Test
     public void testInvalidService1() {
         Package currentPackage = loadPackage("invalid_service_1");
         PackageCompilation compilation = currentPackage.getCompilation();

--- a/kafka-compiler-plugin-tests/src/test/java/io/ballerina/stdlib/kafka/plugin/KafkaCompilerPluginTest.java
+++ b/kafka-compiler-plugin-tests/src/test/java/io/ballerina/stdlib/kafka/plugin/KafkaCompilerPluginTest.java
@@ -25,6 +25,7 @@ import io.ballerina.projects.ProjectEnvironmentBuilder;
 import io.ballerina.projects.directory.BuildProject;
 import io.ballerina.projects.environment.Environment;
 import io.ballerina.projects.environment.EnvironmentBuilder;
+import io.ballerina.stdlib.kafka.plugin.PluginConstants.CompilationErrors;
 import io.ballerina.tools.diagnostics.Diagnostic;
 import org.testng.Assert;
 import org.testng.annotations.Test;
@@ -64,7 +65,7 @@ public class KafkaCompilerPluginTest {
         DiagnosticResult diagnosticResult = compilation.diagnosticResult();
         Assert.assertEquals(diagnosticResult.diagnostics().size(), 1);
         Diagnostic diagnostic = (Diagnostic) diagnosticResult.diagnostics().toArray()[0];
-        assertDiagnostic(diagnostic, PluginConstants.CompilationErrors.NO_ON_CONSUMER_RECORD);
+        assertDiagnostic(diagnostic, CompilationErrors.NO_ON_CONSUMER_RECORD);
     }
 
     @Test
@@ -74,7 +75,7 @@ public class KafkaCompilerPluginTest {
         DiagnosticResult diagnosticResult = compilation.diagnosticResult();
         Assert.assertEquals(diagnosticResult.diagnostics().size(), 1);
         Diagnostic diagnostic = (Diagnostic) diagnosticResult.diagnostics().toArray()[0];
-        assertDiagnostic(diagnostic, PluginConstants.CompilationErrors.INVALID_REMOTE_FUNCTION);
+        assertDiagnostic(diagnostic, CompilationErrors.INVALID_REMOTE_FUNCTION);
     }
 
     @Test
@@ -84,7 +85,7 @@ public class KafkaCompilerPluginTest {
         DiagnosticResult diagnosticResult = compilation.diagnosticResult();
         Assert.assertEquals(diagnosticResult.diagnostics().size(), 1);
         Diagnostic diagnostic = (Diagnostic) diagnosticResult.diagnostics().toArray()[0];
-        assertDiagnostic(diagnostic, PluginConstants.CompilationErrors.FUNCTION_SHOULD_BE_REMOTE);
+        assertDiagnostic(diagnostic, CompilationErrors.FUNCTION_SHOULD_BE_REMOTE);
     }
 
     @Test
@@ -94,7 +95,7 @@ public class KafkaCompilerPluginTest {
         DiagnosticResult diagnosticResult = compilation.diagnosticResult();
         Assert.assertEquals(diagnosticResult.diagnostics().size(), 1);
         Diagnostic diagnostic = (Diagnostic) diagnosticResult.diagnostics().toArray()[0];
-        assertDiagnostic(diagnostic, PluginConstants.CompilationErrors.ONLY_PARAMS_ALLOWED);
+        assertDiagnostic(diagnostic, CompilationErrors.ONLY_PARAMS_ALLOWED);
     }
 
     @Test
@@ -106,7 +107,7 @@ public class KafkaCompilerPluginTest {
         Object[] diagnostics = diagnosticResult.diagnostics().toArray();
         for (Object obj : diagnostics) {
             Diagnostic diagnostic = (Diagnostic) obj;
-            assertDiagnostic(diagnostic, PluginConstants.CompilationErrors.INVALID_FUNCTION_PARAM_CALLER);
+            assertDiagnostic(diagnostic, CompilationErrors.INVALID_FUNCTION_PARAM_CALLER);
         }
     }
 
@@ -117,7 +118,7 @@ public class KafkaCompilerPluginTest {
         DiagnosticResult diagnosticResult = compilation.diagnosticResult();
         Assert.assertEquals(diagnosticResult.diagnostics().size(), 1);
         Diagnostic diagnostic = (Diagnostic) diagnosticResult.diagnostics().toArray()[0];
-        assertDiagnostic(diagnostic, PluginConstants.CompilationErrors.INVALID_RETURN_TYPE_ERROR_OR_NIL);
+        assertDiagnostic(diagnostic, CompilationErrors.INVALID_RETURN_TYPE_ERROR_OR_NIL);
     }
 
     @Test
@@ -127,7 +128,7 @@ public class KafkaCompilerPluginTest {
         DiagnosticResult diagnosticResult = compilation.diagnosticResult();
         Assert.assertEquals(diagnosticResult.diagnostics().size(), 1);
         Diagnostic diagnostic = (Diagnostic) diagnosticResult.diagnostics().toArray()[0];
-        assertDiagnostic(diagnostic, PluginConstants.CompilationErrors.MUST_HAVE_CALLER_AND_RECORDS);
+        assertDiagnostic(diagnostic, CompilationErrors.MUST_HAVE_CALLER_AND_RECORDS);
     }
 
     @Test
@@ -139,7 +140,7 @@ public class KafkaCompilerPluginTest {
         Object[] diagnostics = diagnosticResult.diagnostics().toArray();
         for (Object obj : diagnostics) {
             Diagnostic diagnostic = (Diagnostic) obj;
-            assertDiagnostic(diagnostic, PluginConstants.CompilationErrors.INVALID_FUNCTION_PARAM_RECORDS);
+            assertDiagnostic(diagnostic, CompilationErrors.INVALID_FUNCTION_PARAM_RECORDS);
         }
     }
 
@@ -150,7 +151,17 @@ public class KafkaCompilerPluginTest {
         DiagnosticResult diagnosticResult = compilation.diagnosticResult();
         Assert.assertEquals(diagnosticResult.diagnostics().size(), 1);
         Diagnostic diagnostic = (Diagnostic) diagnosticResult.diagnostics().toArray()[0];
-        assertDiagnostic(diagnostic, PluginConstants.CompilationErrors.INVALID_MULTIPLE_LISTENERS);
+        assertDiagnostic(diagnostic, CompilationErrors.INVALID_MULTIPLE_LISTENERS);
+    }
+
+    @Test
+    public void testInvalidService10() {
+        Package currentPackage = loadPackage("invalid_service_10");
+        PackageCompilation compilation = currentPackage.getCompilation();
+        DiagnosticResult diagnosticResult = compilation.diagnosticResult();
+        Assert.assertEquals(diagnosticResult.diagnostics().size(), 1);
+        Diagnostic diagnostic = (Diagnostic) diagnosticResult.diagnostics().toArray()[0];
+        assertDiagnostic(diagnostic, CompilationErrors.INVALID_FUNCTION);
     }
 
     private Package loadPackage(String path) {

--- a/kafka-compiler-plugin-tests/src/test/resources/ballerina_sources/invalid_service_1/Ballerina.toml
+++ b/kafka-compiler-plugin-tests/src/test/resources/ballerina_sources/invalid_service_1/Ballerina.toml
@@ -1,0 +1,4 @@
+[package]
+org = "kafka_test"
+name = "invalid_service_1"
+version = "0.1.0"

--- a/kafka-compiler-plugin-tests/src/test/resources/ballerina_sources/invalid_service_1/service.bal
+++ b/kafka-compiler-plugin-tests/src/test/resources/ballerina_sources/invalid_service_1/service.bal
@@ -1,0 +1,30 @@
+// Copyright (c) 2021 WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+//
+// WSO2 Inc. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import ballerinax/kafka;
+
+kafka:ConsumerConfiguration consumerConfigs = {
+    groupId: "group-id",
+    topics: ["test-kafka-topic"],
+    pollingInterval: 1,
+    autoCommit: false
+};
+
+listener kafka:Listener kafkaListener =
+        new (kafka:DEFAULT_URL, consumerConfigs);
+
+service kafka:Service on kafkaListener {
+}

--- a/kafka-compiler-plugin-tests/src/test/resources/ballerina_sources/invalid_service_10/Ballerina.toml
+++ b/kafka-compiler-plugin-tests/src/test/resources/ballerina_sources/invalid_service_10/Ballerina.toml
@@ -1,0 +1,4 @@
+[package]
+org = "kafka_test"
+name = "invalid_service_10"
+version = "0.1.0"

--- a/kafka-compiler-plugin-tests/src/test/resources/ballerina_sources/invalid_service_10/service.bal
+++ b/kafka-compiler-plugin-tests/src/test/resources/ballerina_sources/invalid_service_10/service.bal
@@ -1,0 +1,37 @@
+// Copyright (c) 2021 WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+//
+// WSO2 Inc. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import ballerinax/kafka;
+
+kafka:ConsumerConfiguration consumerConfigs = {
+    groupId: "group-id",
+    topics: ["test-kafka-topic"],
+    pollingInterval: 1,
+    autoCommit: false
+};
+
+listener kafka:Listener kafkaListener =
+        new (kafka:DEFAULT_URL, consumerConfigs);
+
+service kafka:Service on kafkaListener {
+    remote function onConsumerRecord(kafka:Caller caller,
+                                kafka:ConsumerRecord[] records) {
+    }
+
+    resource function get greeting() returns string {
+        return "Hello";
+    }
+}

--- a/kafka-compiler-plugin-tests/src/test/resources/ballerina_sources/invalid_service_2/Ballerina.toml
+++ b/kafka-compiler-plugin-tests/src/test/resources/ballerina_sources/invalid_service_2/Ballerina.toml
@@ -1,0 +1,4 @@
+[package]
+org = "kafka_test"
+name = "invalid_service_2"
+version = "0.1.0"

--- a/kafka-compiler-plugin-tests/src/test/resources/ballerina_sources/invalid_service_2/service.bal
+++ b/kafka-compiler-plugin-tests/src/test/resources/ballerina_sources/invalid_service_2/service.bal
@@ -1,0 +1,35 @@
+// Copyright (c) 2021 WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+//
+// WSO2 Inc. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import ballerinax/kafka;
+
+kafka:ConsumerConfiguration consumerConfigs = {
+    groupId: "group-id",
+    topics: ["test-kafka-topic"],
+    pollingInterval: 1,
+    autoCommit: false
+};
+
+listener kafka:Listener kafkaListener =
+        new (kafka:DEFAULT_URL, consumerConfigs);
+
+service kafka:Service on kafkaListener {
+    remote function onConsumerRecord(kafka:Caller caller,
+                                kafka:ConsumerRecord[] records) {
+    }
+
+    remote function someFunction() {}
+}

--- a/kafka-compiler-plugin-tests/src/test/resources/ballerina_sources/invalid_service_3/Ballerina.toml
+++ b/kafka-compiler-plugin-tests/src/test/resources/ballerina_sources/invalid_service_3/Ballerina.toml
@@ -1,0 +1,4 @@
+[package]
+org = "kafka_test"
+name = "invalid_service_3"
+version = "0.1.0"

--- a/kafka-compiler-plugin-tests/src/test/resources/ballerina_sources/invalid_service_3/service.bal
+++ b/kafka-compiler-plugin-tests/src/test/resources/ballerina_sources/invalid_service_3/service.bal
@@ -1,0 +1,33 @@
+// Copyright (c) 2021 WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+//
+// WSO2 Inc. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import ballerinax/kafka;
+
+kafka:ConsumerConfiguration consumerConfigs = {
+    groupId: "group-id",
+    topics: ["test-kafka-topic"],
+    pollingInterval: 1,
+    autoCommit: false
+};
+
+listener kafka:Listener kafkaListener =
+        new (kafka:DEFAULT_URL, consumerConfigs);
+
+service kafka:Service on kafkaListener {
+    function onConsumerRecord(kafka:Caller caller,
+                                kafka:ConsumerRecord[] records) {
+    }
+}

--- a/kafka-compiler-plugin-tests/src/test/resources/ballerina_sources/invalid_service_4/Ballerina.toml
+++ b/kafka-compiler-plugin-tests/src/test/resources/ballerina_sources/invalid_service_4/Ballerina.toml
@@ -1,0 +1,4 @@
+[package]
+org = "kafka_test"
+name = "invalid_service_4"
+version = "0.1.0"

--- a/kafka-compiler-plugin-tests/src/test/resources/ballerina_sources/invalid_service_4/service.bal
+++ b/kafka-compiler-plugin-tests/src/test/resources/ballerina_sources/invalid_service_4/service.bal
@@ -1,0 +1,33 @@
+// Copyright (c) 2021 WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+//
+// WSO2 Inc. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import ballerinax/kafka;
+
+kafka:ConsumerConfiguration consumerConfigs = {
+    groupId: "group-id",
+    topics: ["test-kafka-topic"],
+    pollingInterval: 1,
+    autoCommit: false
+};
+
+listener kafka:Listener kafkaListener =
+        new (kafka:DEFAULT_URL, consumerConfigs);
+
+service kafka:Service on kafkaListener {
+    remote function onConsumerRecord(kafka:Caller caller,
+                                kafka:ConsumerRecord[] records, string data) {
+    }
+}

--- a/kafka-compiler-plugin-tests/src/test/resources/ballerina_sources/invalid_service_5/Ballerina.toml
+++ b/kafka-compiler-plugin-tests/src/test/resources/ballerina_sources/invalid_service_5/Ballerina.toml
@@ -1,0 +1,4 @@
+[package]
+org = "kafka_test"
+name = "invalid_service_5"
+version = "0.1.0"

--- a/kafka-compiler-plugin-tests/src/test/resources/ballerina_sources/invalid_service_5/service.bal
+++ b/kafka-compiler-plugin-tests/src/test/resources/ballerina_sources/invalid_service_5/service.bal
@@ -1,0 +1,39 @@
+// Copyright (c) 2021 WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+//
+// WSO2 Inc. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import ballerinax/kafka;
+
+kafka:ConsumerConfiguration consumerConfigs = {
+    groupId: "group-id",
+    topics: ["test-kafka-topic"],
+    pollingInterval: 1,
+    autoCommit: false
+};
+
+listener kafka:Listener kafkaListener =
+        new (kafka:DEFAULT_URL, consumerConfigs);
+
+service kafka:Service on kafkaListener {
+    remote function onConsumerRecord(string caller,
+                                kafka:ConsumerRecord[] records) {
+    }
+}
+
+service kafka:Service on kafkaListener {
+    remote function onConsumerRecord(kafka:Consumer caller,
+                                kafka:ConsumerRecord[] records) {
+    }
+}

--- a/kafka-compiler-plugin-tests/src/test/resources/ballerina_sources/invalid_service_6/Ballerina.toml
+++ b/kafka-compiler-plugin-tests/src/test/resources/ballerina_sources/invalid_service_6/Ballerina.toml
@@ -1,0 +1,4 @@
+[package]
+org = "kafka_test"
+name = "invalid_service_6"
+version = "0.1.0"

--- a/kafka-compiler-plugin-tests/src/test/resources/ballerina_sources/invalid_service_6/service.bal
+++ b/kafka-compiler-plugin-tests/src/test/resources/ballerina_sources/invalid_service_6/service.bal
@@ -1,0 +1,34 @@
+// Copyright (c) 2021 WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+//
+// WSO2 Inc. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import ballerinax/kafka;
+
+kafka:ConsumerConfiguration consumerConfigs = {
+    groupId: "group-id",
+    topics: ["test-kafka-topic"],
+    pollingInterval: 1,
+    autoCommit: false
+};
+
+listener kafka:Listener kafkaListener =
+        new (kafka:DEFAULT_URL, consumerConfigs);
+
+service kafka:Service on kafkaListener {
+    remote function onConsumerRecord(kafka:Caller caller,
+                                kafka:ConsumerRecord[] records) returns string {
+        return "Hello";
+    }
+}

--- a/kafka-compiler-plugin-tests/src/test/resources/ballerina_sources/invalid_service_7/Ballerina.toml
+++ b/kafka-compiler-plugin-tests/src/test/resources/ballerina_sources/invalid_service_7/Ballerina.toml
@@ -1,0 +1,4 @@
+[package]
+org = "kafka_test"
+name = "invalid_service_7"
+version = "0.1.0"

--- a/kafka-compiler-plugin-tests/src/test/resources/ballerina_sources/invalid_service_7/service.bal
+++ b/kafka-compiler-plugin-tests/src/test/resources/ballerina_sources/invalid_service_7/service.bal
@@ -1,0 +1,32 @@
+// Copyright (c) 2021 WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+//
+// WSO2 Inc. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import ballerinax/kafka;
+
+kafka:ConsumerConfiguration consumerConfigs = {
+    groupId: "group-id",
+    topics: ["test-kafka-topic"],
+    pollingInterval: 1,
+    autoCommit: false
+};
+
+listener kafka:Listener kafkaListener =
+        new (kafka:DEFAULT_URL, consumerConfigs);
+
+service kafka:Service on kafkaListener {
+    remote function onConsumerRecord(kafka:Caller caller) {
+    }
+}

--- a/kafka-compiler-plugin-tests/src/test/resources/ballerina_sources/invalid_service_8/Ballerina.toml
+++ b/kafka-compiler-plugin-tests/src/test/resources/ballerina_sources/invalid_service_8/Ballerina.toml
@@ -1,0 +1,4 @@
+[package]
+org = "kafka_test"
+name = "invalid_service_8"
+version = "0.1.0"

--- a/kafka-compiler-plugin-tests/src/test/resources/ballerina_sources/invalid_service_8/service.bal
+++ b/kafka-compiler-plugin-tests/src/test/resources/ballerina_sources/invalid_service_8/service.bal
@@ -1,0 +1,45 @@
+// Copyright (c) 2021 WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+//
+// WSO2 Inc. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import ballerinax/kafka;
+
+kafka:ConsumerConfiguration consumerConfigs = {
+    groupId: "group-id",
+    topics: ["test-kafka-topic"],
+    pollingInterval: 1,
+    autoCommit: false
+};
+
+listener kafka:Listener kafkaListener =
+        new (kafka:DEFAULT_URL, consumerConfigs);
+
+service kafka:Service on kafkaListener {
+    remote function onConsumerRecord(kafka:Caller caller,
+                                kafka:Consumer records) {
+    }
+}
+
+service kafka:Service on kafkaListener {
+    remote function onConsumerRecord(kafka:Caller caller,
+                                kafka:Consumer[] records) {
+    }
+}
+
+service kafka:Service on kafkaListener {
+    remote function onConsumerRecord(kafka:Caller caller,
+                                string[] records) {
+    }
+}

--- a/kafka-compiler-plugin-tests/src/test/resources/ballerina_sources/invalid_service_9/Ballerina.toml
+++ b/kafka-compiler-plugin-tests/src/test/resources/ballerina_sources/invalid_service_9/Ballerina.toml
@@ -1,0 +1,4 @@
+[package]
+org = "kafka_test"
+name = "invalid_service_9"
+version = "0.1.0"

--- a/kafka-compiler-plugin-tests/src/test/resources/ballerina_sources/invalid_service_9/service.bal
+++ b/kafka-compiler-plugin-tests/src/test/resources/ballerina_sources/invalid_service_9/service.bal
@@ -1,0 +1,35 @@
+// Copyright (c) 2021 WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+//
+// WSO2 Inc. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import ballerinax/kafka;
+
+kafka:ConsumerConfiguration consumerConfigs = {
+    groupId: "group-id",
+    topics: ["test-kafka-topic"],
+    pollingInterval: 1,
+    autoCommit: false
+};
+
+listener kafka:Listener kafkaListener1 =
+        new (kafka:DEFAULT_URL, consumerConfigs);
+listener kafka:Listener kafkaListener2 =
+        new (kafka:DEFAULT_URL, consumerConfigs);
+
+service kafka:Service on kafkaListener1, kafkaListener2 {
+    remote function onConsumerRecord(kafka:Caller caller,
+                                kafka:ConsumerRecord[] records) {
+    }
+}

--- a/kafka-compiler-plugin-tests/src/test/resources/ballerina_sources/testng.xml
+++ b/kafka-compiler-plugin-tests/src/test/resources/ballerina_sources/testng.xml
@@ -1,0 +1,27 @@
+<!--
+  ~ Copyright (c) 2021, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+  ~
+  ~ WSO2 Inc. licenses this file to you under the Apache License,
+  ~ Version 2.0 (the "License"); you may not use this file except
+  ~ in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~    http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing,
+  ~ software distributed under the License is distributed on an
+  ~ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+  ~ KIND, either express or implied. See the License for the
+  ~ specific language governing permissions and limitations
+  ~ under the License.
+  -->
+
+<!DOCTYPE suite SYSTEM "http://testng.org/testng-1.0.dtd" >
+
+<suite name="BallerinaGraphqlCompilerPluginTests">
+    <test name="UnitTests">
+        <classes>
+            <class name="io.ballerina.stdlib.kafka.plugin.KafkaCompilerPluginTest"/>
+        </classes>
+    </test>
+</suite>

--- a/kafka-compiler-plugin-tests/src/test/resources/ballerina_sources/valid_service_1/Ballerina.toml
+++ b/kafka-compiler-plugin-tests/src/test/resources/ballerina_sources/valid_service_1/Ballerina.toml
@@ -1,0 +1,4 @@
+[package]
+org = "kafka_test"
+name = "valid_service_1"
+version = "0.1.0"

--- a/kafka-compiler-plugin-tests/src/test/resources/ballerina_sources/valid_service_1/service.bal
+++ b/kafka-compiler-plugin-tests/src/test/resources/ballerina_sources/valid_service_1/service.bal
@@ -1,0 +1,57 @@
+// Copyright (c) 2021 WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+//
+// WSO2 Inc. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import ballerinax/kafka;
+
+kafka:ConsumerConfiguration consumerConfigs = {
+    groupId: "group-id",
+    topics: ["test-kafka-topic"],
+    pollingInterval: 1,
+    autoCommit: false
+};
+
+listener kafka:Listener kafkaListener =
+        new (kafka:DEFAULT_URL, consumerConfigs);
+
+service kafka:Service on kafkaListener {
+    remote function onConsumerRecord(kafka:Caller caller,
+                                kafka:ConsumerRecord[] records) {
+    }
+}
+
+service kafka:Service on kafkaListener {
+    remote function onConsumerRecord(kafka:Caller caller,
+                                kafka:ConsumerRecord[] records) returns error? {
+    }
+}
+
+service kafka:Service on kafkaListener {
+    remote function onConsumerRecord(kafka:Caller caller,
+                                kafka:ConsumerRecord[] records) returns kafka:Error? {
+    }
+}
+
+service kafka:Service on kafkaListener {
+    remote function onConsumerRecord(kafka:Caller caller,
+                                kafka:ConsumerRecord[] records) returns ()|kafka:Error {
+    }
+}
+
+service kafka:Service on kafkaListener {
+    remote function onConsumerRecord(kafka:Caller caller,
+                                kafka:ConsumerRecord[] records) returns ()|error {
+    }
+}

--- a/kafka-compiler-plugin-tests/src/test/resources/ballerina_sources/valid_service_2/Ballerina.toml
+++ b/kafka-compiler-plugin-tests/src/test/resources/ballerina_sources/valid_service_2/Ballerina.toml
@@ -1,0 +1,4 @@
+[package]
+org = "kafka_test"
+name = "valid_service_2"
+version = "0.1.0"

--- a/kafka-compiler-plugin-tests/src/test/resources/ballerina_sources/valid_service_2/service.bal
+++ b/kafka-compiler-plugin-tests/src/test/resources/ballerina_sources/valid_service_2/service.bal
@@ -1,0 +1,33 @@
+// Copyright (c) 2021 WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+//
+// WSO2 Inc. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import ballerinax/kafka as foo;
+
+foo:ConsumerConfiguration consumerConfigs = {
+    groupId: "group-id",
+    topics: ["test-kafka-topic"],
+    pollingInterval: 1,
+    autoCommit: false
+};
+
+listener foo:Listener kafkaListener =
+        new (foo:DEFAULT_URL, consumerConfigs);
+
+service foo:Service on kafkaListener {
+    remote function onConsumerRecord(foo:Caller caller,
+                                foo:ConsumerRecord[] records) {
+    }
+}

--- a/kafka-compiler-plugin/build.gradle
+++ b/kafka-compiler-plugin/build.gradle
@@ -1,0 +1,72 @@
+/*
+ * Copyright (c) 2021, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+plugins {
+    id 'java'
+    id 'checkstyle'
+    id 'com.github.spotbugs'
+}
+
+description = 'Ballerina - Kafka Compiler Plugin'
+
+dependencies {
+    checkstyle project(':build-config:checkstyle')
+    checkstyle "com.puppycrawl.tools:checkstyle:${puppycrawlCheckstyleVersion}"
+    implementation group: 'org.ballerinalang', name: 'ballerina-lang', version: "${ballerinaLangVersion}"
+    implementation group: 'org.ballerinalang', name: 'ballerina-parser', version: "${ballerinaLangVersion}"
+    implementation group: 'org.ballerinalang', name: 'ballerina-tools-api', version: "${ballerinaLangVersion}"
+}
+
+checkstyle {
+    toolVersion '7.8.2'
+    configFile rootProject.file("build-config/checkstyle/build/checkstyle.xml")
+    configProperties = ["suppressionFile" : file("${rootDir}/build-config/checkstyle/build/suppressions.xml")]
+}
+
+def excludePattern = '**/module-info.java'
+tasks.withType(Checkstyle) {
+    exclude excludePattern
+}
+
+checkstyleMain.dependsOn(":build-config:checkstyle:downloadMultipleFiles")
+
+spotbugsMain {
+    effort "max"
+    reportLevel "low"
+    reportsDir = file("$project.buildDir/reports/spotbugs")
+    reports {
+        html.enabled true
+        text.enabled = true
+    }
+    def excludeFile = file("${rootDir}/spotbugs-exclude.xml")
+    if(excludeFile.exists()) {
+        excludeFilter = excludeFile
+    }
+}
+
+spotbugsTest {
+    enabled = false
+}
+
+compileJava {
+    doFirst {
+        options.compilerArgs = [
+                '--module-path', classpath.asPath,
+        ]
+        classpath = files()
+    }
+}

--- a/kafka-compiler-plugin/src/main/java/io/ballerina/stdlib/kafka/plugin/KafkaCodeAnalyzer.java
+++ b/kafka-compiler-plugin/src/main/java/io/ballerina/stdlib/kafka/plugin/KafkaCodeAnalyzer.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright (c) 2021, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package io.ballerina.stdlib.kafka.plugin;
+
+import io.ballerina.compiler.syntax.tree.SyntaxKind;
+import io.ballerina.projects.plugins.CodeAnalysisContext;
+import io.ballerina.projects.plugins.CodeAnalyzer;
+
+/**
+ * Code analyzer for Kafka package.
+ */
+public class KafkaCodeAnalyzer extends CodeAnalyzer {
+    @Override
+    public void init(CodeAnalysisContext codeAnalysisContext) {
+        codeAnalysisContext.addSyntaxNodeAnalysisTask(new KafkaServiceAnalysisTask(), SyntaxKind.SERVICE_DECLARATION);
+    }
+}

--- a/kafka-compiler-plugin/src/main/java/io/ballerina/stdlib/kafka/plugin/KafkaCompilerPlugin.java
+++ b/kafka-compiler-plugin/src/main/java/io/ballerina/stdlib/kafka/plugin/KafkaCompilerPlugin.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright (c) 2021, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package io.ballerina.stdlib.kafka.plugin;
+
+import io.ballerina.projects.plugins.CompilerPlugin;
+import io.ballerina.projects.plugins.CompilerPluginContext;
+
+/**
+ * Compiler plugin for Kafka package.
+ */
+public class KafkaCompilerPlugin extends CompilerPlugin {
+
+    @Override
+    public void init(CompilerPluginContext compilerPluginContext) {
+        compilerPluginContext.addCodeAnalyzer(new KafkaCodeAnalyzer());
+    }
+}

--- a/kafka-compiler-plugin/src/main/java/io/ballerina/stdlib/kafka/plugin/KafkaFunctionValidator.java
+++ b/kafka-compiler-plugin/src/main/java/io/ballerina/stdlib/kafka/plugin/KafkaFunctionValidator.java
@@ -1,0 +1,162 @@
+/*
+ * Copyright (c) 2021, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package io.ballerina.stdlib.kafka.plugin;
+
+import io.ballerina.compiler.syntax.tree.ArrayTypeDescriptorNode;
+import io.ballerina.compiler.syntax.tree.FunctionDefinitionNode;
+import io.ballerina.compiler.syntax.tree.IdentifierToken;
+import io.ballerina.compiler.syntax.tree.Node;
+import io.ballerina.compiler.syntax.tree.ParameterNode;
+import io.ballerina.compiler.syntax.tree.QualifiedNameReferenceNode;
+import io.ballerina.compiler.syntax.tree.RequiredParameterNode;
+import io.ballerina.compiler.syntax.tree.ReturnTypeDescriptorNode;
+import io.ballerina.compiler.syntax.tree.SeparatedNodeList;
+import io.ballerina.compiler.syntax.tree.ServiceDeclarationNode;
+import io.ballerina.compiler.syntax.tree.SyntaxKind;
+import io.ballerina.compiler.syntax.tree.Token;
+import io.ballerina.compiler.syntax.tree.TypeDescriptorNode;
+import io.ballerina.projects.plugins.SyntaxNodeAnalysisContext;
+import io.ballerina.stdlib.kafka.plugin.PluginConstants.CompilationErrors;
+import io.ballerina.tools.diagnostics.DiagnosticSeverity;
+
+import java.util.Objects;
+import java.util.Optional;
+
+/**
+ * Kafka remote function validator.
+ */
+public class KafkaFunctionValidator {
+
+    private final SyntaxNodeAnalysisContext context;
+    private final ServiceDeclarationNode serviceDeclarationNode;
+    FunctionDefinitionNode onConsumerRecord;
+
+    public KafkaFunctionValidator(SyntaxNodeAnalysisContext context, FunctionDefinitionNode onConsumerRecord) {
+        this.context = context;
+        this.serviceDeclarationNode = (ServiceDeclarationNode) context.node();
+        this.onConsumerRecord = onConsumerRecord;
+    }
+
+    public void validate() {
+        validateMandatoryFunction();
+        if (Objects.nonNull(onConsumerRecord)) {
+            validateOnConsumerRecord();
+        }
+    }
+
+    private void validateMandatoryFunction() {
+        if (Objects.isNull(onConsumerRecord)) {
+            context.reportDiagnostic(PluginUtils.getDiagnostic(CompilationErrors.NO_ON_CONSUMER_RECORD,
+                    DiagnosticSeverity.ERROR, serviceDeclarationNode.location()));
+        }
+    }
+
+    private void validateOnConsumerRecord() {
+        if (!PluginUtils.isRemoteFunction(context, onConsumerRecord)) {
+            context.reportDiagnostic(PluginUtils.getDiagnostic(
+                    PluginConstants.CompilationErrors.FUNCTION_SHOULD_BE_REMOTE,
+                    DiagnosticSeverity.ERROR, onConsumerRecord.functionSignature().location()));
+        }
+        SeparatedNodeList<ParameterNode> parameters = onConsumerRecord.functionSignature().parameters();
+        validateFunctionParameters(parameters, onConsumerRecord);
+        validateReturnTypeErrorOrNil(onConsumerRecord);
+    }
+
+    private void validateFunctionParameters(SeparatedNodeList<ParameterNode> parameters,
+                                            FunctionDefinitionNode functionDefinitionNode) {
+        if (parameters.size() > 1) {
+            validateFirstParam(functionDefinitionNode, parameters.get(0));
+            validateSecondParam(functionDefinitionNode, parameters.get(1));
+        }
+        if (parameters.size() > 2) {
+            context.reportDiagnostic(PluginUtils.getDiagnostic(CompilationErrors.ONLY_PARAMS_ALLOWED,
+                    DiagnosticSeverity.ERROR, functionDefinitionNode.functionSignature().location()));
+        }
+        if (parameters.size() < 2) {
+            context.reportDiagnostic(PluginUtils.getDiagnostic(CompilationErrors.MUST_HAVE_CALLER_AND_RECORDS,
+                    DiagnosticSeverity.ERROR, functionDefinitionNode.functionSignature().location()));
+        }
+    }
+
+    private void validateFirstParam(FunctionDefinitionNode functionDefinitionNode, ParameterNode parameterNode) {
+        RequiredParameterNode requiredParameterNode = (RequiredParameterNode) parameterNode;
+        Node parameterTypeNode = requiredParameterNode.typeName();
+        if (!parameterTypeNode.kind().equals(SyntaxKind.QUALIFIED_NAME_REFERENCE)) {
+            context.reportDiagnostic(PluginUtils.getDiagnostic(
+                    CompilationErrors.INVALID_FUNCTION_PARAM_CALLER,
+                    DiagnosticSeverity.ERROR, functionDefinitionNode.location()));
+        } else {
+            Token modulePrefix = ((QualifiedNameReferenceNode) parameterTypeNode).modulePrefix();
+            IdentifierToken identifierToken = ((QualifiedNameReferenceNode) parameterTypeNode).identifier();
+            if (!modulePrefix.text().equals(PluginConstants.PACKAGE_PREFIX) ||
+                    !identifierToken.text().equals(PluginConstants.CALLER)) {
+                context.reportDiagnostic(PluginUtils.getDiagnostic(
+                        CompilationErrors.INVALID_FUNCTION_PARAM_CALLER,
+                        DiagnosticSeverity.ERROR, functionDefinitionNode.location()));
+            }
+        }
+    }
+
+    private void validateSecondParam(FunctionDefinitionNode functionDefinitionNode,
+                                     ParameterNode parameterNode) {
+        RequiredParameterNode requiredParameterNode = (RequiredParameterNode) parameterNode;
+        Node parameterTypeNode = requiredParameterNode.typeName();
+        if (!parameterTypeNode.kind().equals(SyntaxKind.ARRAY_TYPE_DESC)) {
+            context.reportDiagnostic(PluginUtils.getDiagnostic(
+                    CompilationErrors.INVALID_FUNCTION_PARAM_RECORDS,
+                    DiagnosticSeverity.ERROR, functionDefinitionNode.location()));
+        } else {
+            ArrayTypeDescriptorNode arrayTypeDescriptorNode = (ArrayTypeDescriptorNode) parameterTypeNode;
+            TypeDescriptorNode memberType = arrayTypeDescriptorNode.memberTypeDesc();
+            if (memberType.kind() != SyntaxKind.QUALIFIED_NAME_REFERENCE) {
+                context.reportDiagnostic(PluginUtils.getDiagnostic(
+                        CompilationErrors.INVALID_FUNCTION_PARAM_RECORDS,
+                        DiagnosticSeverity.ERROR, functionDefinitionNode.location()));
+            } else {
+                Token modulePrefix =
+                        ((QualifiedNameReferenceNode) arrayTypeDescriptorNode.memberTypeDesc()).modulePrefix();
+                IdentifierToken identifierToken =
+                        ((QualifiedNameReferenceNode) arrayTypeDescriptorNode.memberTypeDesc()).identifier();
+                if (!modulePrefix.text().equals(PluginConstants.PACKAGE_PREFIX) ||
+                        !identifierToken.text().equals(PluginConstants.RECORD_PARAM)) {
+                    context.reportDiagnostic(PluginUtils.getDiagnostic(
+                            CompilationErrors.INVALID_FUNCTION_PARAM_RECORDS,
+                            DiagnosticSeverity.ERROR, functionDefinitionNode.location()));
+                }
+            }
+        }
+    }
+
+    private void validateReturnTypeErrorOrNil(FunctionDefinitionNode functionDefinitionNode) {
+        Optional<ReturnTypeDescriptorNode> returnTypes = functionDefinitionNode.functionSignature().returnTypeDesc();
+        if (returnTypes.isPresent()) {
+            ReturnTypeDescriptorNode returnTypeDescriptorNode = returnTypes.get();
+            Node returnNodeType = returnTypeDescriptorNode.type();
+            String returnType = returnNodeType.toString().split(" ")[0];
+            if (!returnType.equals(PluginConstants.ERROR_OR_NIL) &&
+                    !returnType.equals(PluginConstants.NIL_OR_ERROR) &&
+                    !returnType.equals(PluginConstants.KAFKA_ERROR_OR_NIL) &&
+                    !returnType.equals(PluginConstants.NIL_OR_KAFKA_ERROR)) {
+                context.reportDiagnostic(PluginUtils.getDiagnostic(
+                        PluginConstants.CompilationErrors.INVALID_RETURN_TYPE_ERROR_OR_NIL,
+                        DiagnosticSeverity.ERROR, functionDefinitionNode.location()));
+            }
+        }
+    }
+}

--- a/kafka-compiler-plugin/src/main/java/io/ballerina/stdlib/kafka/plugin/KafkaServiceAnalysisTask.java
+++ b/kafka-compiler-plugin/src/main/java/io/ballerina/stdlib/kafka/plugin/KafkaServiceAnalysisTask.java
@@ -40,12 +40,17 @@ import static io.ballerina.stdlib.kafka.plugin.PluginUtils.validateModuleId;
  * Kafka service compilation analysis task.
  */
 public class KafkaServiceAnalysisTask implements AnalysisTask<SyntaxNodeAnalysisContext> {
+    private final KafkaServiceValidator serviceValidator;
+
+    public KafkaServiceAnalysisTask() {
+        this.serviceValidator = new KafkaServiceValidator();
+    }
     @Override
     public void perform(SyntaxNodeAnalysisContext context) {
         if (!isKafkaService(context)) {
             return;
         }
-        new KafkaServiceValidator(context).validate();
+        this.serviceValidator.validate(context);
     }
 
     private boolean isKafkaService(SyntaxNodeAnalysisContext context) {

--- a/kafka-compiler-plugin/src/main/java/io/ballerina/stdlib/kafka/plugin/KafkaServiceAnalysisTask.java
+++ b/kafka-compiler-plugin/src/main/java/io/ballerina/stdlib/kafka/plugin/KafkaServiceAnalysisTask.java
@@ -61,7 +61,7 @@ public class KafkaServiceAnalysisTask implements AnalysisTask<SyntaxNodeAnalysis
         if (symbol.isPresent()) {
             ServiceDeclarationSymbol serviceDeclarationSymbol = (ServiceDeclarationSymbol) symbol.get();
             List<TypeSymbol> listeners = serviceDeclarationSymbol.listenerTypes();
-            if (listeners.size() > 1) {
+            if (listeners.size() > 1 && hasKafkaListener(listeners)) {
                 context.reportDiagnostic(PluginUtils.getDiagnostic(CompilationErrors.INVALID_MULTIPLE_LISTENERS,
                         DiagnosticSeverity.ERROR, serviceDeclarationNode.location()));
             } else {
@@ -83,5 +83,15 @@ public class KafkaServiceAnalysisTask implements AnalysisTask<SyntaxNodeAnalysis
             }
         }
         return isKafkaService;
+    }
+
+
+    private boolean hasKafkaListener(List<TypeSymbol> listeners) {
+        for (TypeSymbol listener: listeners) {
+            if (validateModuleId(listener.getModule().get())) {
+                return true;
+            }
+        }
+        return false;
     }
 }

--- a/kafka-compiler-plugin/src/main/java/io/ballerina/stdlib/kafka/plugin/KafkaServiceAnalysisTask.java
+++ b/kafka-compiler-plugin/src/main/java/io/ballerina/stdlib/kafka/plugin/KafkaServiceAnalysisTask.java
@@ -34,6 +34,8 @@ import io.ballerina.tools.diagnostics.DiagnosticSeverity;
 import java.util.List;
 import java.util.Optional;
 
+import static io.ballerina.stdlib.kafka.plugin.PluginUtils.validateModuleId;
+
 /**
  * Kafka service compilation analysis task.
  */
@@ -64,19 +66,13 @@ public class KafkaServiceAnalysisTask implements AnalysisTask<SyntaxNodeAnalysis
                     for (TypeSymbol memberSymbol : members) {
                         Optional<ModuleSymbol> module = memberSymbol.getModule();
                         if (module.isPresent()) {
-                            String moduleName = module.get().id().moduleName();
-                            String orgName = module.get().id().orgName();
-                            isKafkaService = moduleName.equals(PluginConstants.PACKAGE_PREFIX) &&
-                                    orgName.equals(PluginConstants.PACKAGE_ORG);
+                            isKafkaService = validateModuleId(module.get());
                         }
                     }
                 } else {
                     Optional<ModuleSymbol> module = listeners.get(0).getModule();
                     if (module.isPresent()) {
-                        String moduleName = module.get().id().moduleName();
-                        String orgName = module.get().id().orgName();
-                        isKafkaService = moduleName.equals(PluginConstants.PACKAGE_PREFIX) &&
-                                orgName.equals(PluginConstants.PACKAGE_ORG);
+                        isKafkaService = validateModuleId(module.get());
                     }
                 }
             }

--- a/kafka-compiler-plugin/src/main/java/io/ballerina/stdlib/kafka/plugin/KafkaServiceAnalysisTask.java
+++ b/kafka-compiler-plugin/src/main/java/io/ballerina/stdlib/kafka/plugin/KafkaServiceAnalysisTask.java
@@ -1,0 +1,86 @@
+/*
+ * Copyright (c) 2021, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package io.ballerina.stdlib.kafka.plugin;
+
+import io.ballerina.compiler.api.SemanticModel;
+import io.ballerina.compiler.api.symbols.ModuleSymbol;
+import io.ballerina.compiler.api.symbols.ServiceDeclarationSymbol;
+import io.ballerina.compiler.api.symbols.Symbol;
+import io.ballerina.compiler.api.symbols.TypeDescKind;
+import io.ballerina.compiler.api.symbols.TypeSymbol;
+import io.ballerina.compiler.api.symbols.UnionTypeSymbol;
+import io.ballerina.compiler.syntax.tree.ServiceDeclarationNode;
+import io.ballerina.projects.plugins.AnalysisTask;
+import io.ballerina.projects.plugins.SyntaxNodeAnalysisContext;
+import io.ballerina.stdlib.kafka.plugin.PluginConstants.CompilationErrors;
+import io.ballerina.tools.diagnostics.DiagnosticSeverity;
+
+import java.util.List;
+import java.util.Optional;
+
+/**
+ * Kafka service compilation analysis task.
+ */
+public class KafkaServiceAnalysisTask implements AnalysisTask<SyntaxNodeAnalysisContext> {
+    @Override
+    public void perform(SyntaxNodeAnalysisContext context) {
+        if (!isKafkaService(context)) {
+            return;
+        }
+        new KafkaServiceValidator(context).validate();
+    }
+
+    private boolean isKafkaService(SyntaxNodeAnalysisContext context) {
+        boolean isKafkaService = false;
+        SemanticModel semanticModel = context.semanticModel();
+        ServiceDeclarationNode serviceDeclarationNode = (ServiceDeclarationNode) context.node();
+        Optional<Symbol> symbol = semanticModel.symbol(serviceDeclarationNode);
+        if (symbol.isPresent()) {
+            ServiceDeclarationSymbol serviceDeclarationSymbol = (ServiceDeclarationSymbol) symbol.get();
+            List<TypeSymbol> listeners = serviceDeclarationSymbol.listenerTypes();
+            if (listeners.size() > 1) {
+                context.reportDiagnostic(PluginUtils.getDiagnostic(CompilationErrors.INVALID_MULTIPLE_LISTENERS,
+                        DiagnosticSeverity.ERROR, serviceDeclarationNode.location()));
+            } else {
+                if (listeners.get(0).typeKind() == TypeDescKind.UNION) {
+                    UnionTypeSymbol unionTypeSymbol = (UnionTypeSymbol) listeners.get(0);
+                    List<TypeSymbol> members = unionTypeSymbol.memberTypeDescriptors();
+                    for (TypeSymbol memberSymbol : members) {
+                        Optional<ModuleSymbol> module = memberSymbol.getModule();
+                        if (module.isPresent()) {
+                            String moduleName = module.get().id().moduleName();
+                            String orgName = module.get().id().orgName();
+                            isKafkaService = moduleName.equals(PluginConstants.PACKAGE_PREFIX) &&
+                                    orgName.equals(PluginConstants.PACKAGE_ORG);
+                        }
+                    }
+                } else {
+                    Optional<ModuleSymbol> module = listeners.get(0).getModule();
+                    if (module.isPresent()) {
+                        String moduleName = module.get().id().moduleName();
+                        String orgName = module.get().id().orgName();
+                        isKafkaService = moduleName.equals(PluginConstants.PACKAGE_PREFIX) &&
+                                orgName.equals(PluginConstants.PACKAGE_ORG);
+                    }
+                }
+            }
+        }
+        return isKafkaService;
+    }
+}

--- a/kafka-compiler-plugin/src/main/java/io/ballerina/stdlib/kafka/plugin/KafkaServiceValidator.java
+++ b/kafka-compiler-plugin/src/main/java/io/ballerina/stdlib/kafka/plugin/KafkaServiceValidator.java
@@ -1,0 +1,94 @@
+/*
+ * Copyright (c) 2021, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package io.ballerina.stdlib.kafka.plugin;
+
+import io.ballerina.compiler.api.SemanticModel;
+import io.ballerina.compiler.api.symbols.AnnotationSymbol;
+import io.ballerina.compiler.api.symbols.MethodSymbol;
+import io.ballerina.compiler.api.symbols.ServiceDeclarationSymbol;
+import io.ballerina.compiler.api.symbols.Symbol;
+import io.ballerina.compiler.syntax.tree.FunctionDefinitionNode;
+import io.ballerina.compiler.syntax.tree.Node;
+import io.ballerina.compiler.syntax.tree.NodeList;
+import io.ballerina.compiler.syntax.tree.ServiceDeclarationNode;
+import io.ballerina.compiler.syntax.tree.SyntaxKind;
+import io.ballerina.projects.plugins.SyntaxNodeAnalysisContext;
+import io.ballerina.stdlib.kafka.plugin.PluginConstants.CompilationErrors;
+import io.ballerina.tools.diagnostics.DiagnosticSeverity;
+
+import java.util.List;
+import java.util.Optional;
+
+/**
+ * Kafka service compilation validator.
+ */
+public class KafkaServiceValidator {
+    private final SyntaxNodeAnalysisContext context;
+    private final NodeList<Node> memberNodes;
+
+    public KafkaServiceValidator(SyntaxNodeAnalysisContext context) {
+        this.context = context;
+        ServiceDeclarationNode serviceDeclarationNode = (ServiceDeclarationNode) context.node();
+        this.memberNodes = serviceDeclarationNode.members();
+    }
+
+    public void validate() {
+        validateAnnotation(this.context);
+        FunctionDefinitionNode onConsumerRecord = null;
+
+        if (!memberNodes.isEmpty()) {
+            for (Node node : memberNodes) {
+                FunctionDefinitionNode functionDefinitionNode = (FunctionDefinitionNode) node;
+                if (node.kind() == SyntaxKind.OBJECT_METHOD_DEFINITION) {
+                    MethodSymbol methodSymbol = PluginUtils.getMethodSymbol(context, functionDefinitionNode);
+                    Optional<String> functionName = methodSymbol.getName();
+                    if (functionName.isPresent()) {
+                        if (functionName.get().equals(PluginConstants.ON_RECORDS_FUNC)) {
+                            onConsumerRecord = functionDefinitionNode;
+                        } else {
+                            validateNonStanFunction(functionDefinitionNode);
+                        }
+                    }
+                }
+            }
+        }
+        new KafkaFunctionValidator(context, onConsumerRecord).validate();
+    }
+
+    public void validateNonStanFunction(FunctionDefinitionNode functionDefinitionNode) {
+        if (PluginUtils.isRemoteFunction(context, functionDefinitionNode)) {
+            context.reportDiagnostic(PluginUtils.getDiagnostic(CompilationErrors.INVALID_REMOTE_FUNCTION,
+                    DiagnosticSeverity.ERROR, functionDefinitionNode.location()));
+        }
+    }
+
+    private void validateAnnotation(SyntaxNodeAnalysisContext context) {
+        SemanticModel semanticModel = context.semanticModel();
+        ServiceDeclarationNode serviceDeclarationNode = (ServiceDeclarationNode) context.node();
+        Optional<Symbol> symbol = semanticModel.symbol(serviceDeclarationNode);
+        if (symbol.isPresent()) {
+            ServiceDeclarationSymbol serviceDeclarationSymbol = (ServiceDeclarationSymbol) symbol.get();
+            List<AnnotationSymbol> symbolList = serviceDeclarationSymbol.annotations();
+            if (!symbolList.isEmpty()) {
+                context.reportDiagnostic(PluginUtils.getDiagnostic(CompilationErrors.INVALID_ANNOTATION_NUMBER,
+                        DiagnosticSeverity.ERROR, serviceDeclarationNode.location()));
+            }
+        }
+    }
+}

--- a/kafka-compiler-plugin/src/main/java/io/ballerina/stdlib/kafka/plugin/KafkaServiceValidator.java
+++ b/kafka-compiler-plugin/src/main/java/io/ballerina/stdlib/kafka/plugin/KafkaServiceValidator.java
@@ -52,18 +52,16 @@ public class KafkaServiceValidator {
         validateAnnotation(this.context);
         FunctionDefinitionNode onConsumerRecord = null;
 
-        if (!memberNodes.isEmpty()) {
-            for (Node node : memberNodes) {
-                FunctionDefinitionNode functionDefinitionNode = (FunctionDefinitionNode) node;
-                if (node.kind() == SyntaxKind.OBJECT_METHOD_DEFINITION) {
-                    MethodSymbol methodSymbol = PluginUtils.getMethodSymbol(context, functionDefinitionNode);
-                    Optional<String> functionName = methodSymbol.getName();
-                    if (functionName.isPresent()) {
-                        if (functionName.get().equals(PluginConstants.ON_RECORDS_FUNC)) {
-                            onConsumerRecord = functionDefinitionNode;
-                        } else {
-                            validateNonStanFunction(functionDefinitionNode);
-                        }
+        for (Node node : memberNodes) {
+            FunctionDefinitionNode functionDefinitionNode = (FunctionDefinitionNode) node;
+            if (node.kind() == SyntaxKind.OBJECT_METHOD_DEFINITION) {
+                MethodSymbol methodSymbol = PluginUtils.getMethodSymbol(context, functionDefinitionNode);
+                Optional<String> functionName = methodSymbol.getName();
+                if (functionName.isPresent()) {
+                    if (functionName.get().equals(PluginConstants.ON_RECORDS_FUNC)) {
+                        onConsumerRecord = functionDefinitionNode;
+                    } else {
+                        validateNonStanFunction(functionDefinitionNode);
                     }
                 }
             }

--- a/kafka-compiler-plugin/src/main/java/io/ballerina/stdlib/kafka/plugin/KafkaServiceValidator.java
+++ b/kafka-compiler-plugin/src/main/java/io/ballerina/stdlib/kafka/plugin/KafkaServiceValidator.java
@@ -56,19 +56,26 @@ public class KafkaServiceValidator {
                     if (functionName.get().equals(PluginConstants.ON_RECORDS_FUNC)) {
                         onConsumerRecord = functionDefinitionNode;
                     } else {
-                        validateNonStanFunction(functionDefinitionNode, context);
+                        validateNonKafkaFunction(functionDefinitionNode, context);
                     }
                 }
+            } else {
+                validateNonKafkaFunction(functionDefinitionNode, context);
             }
         }
         new KafkaFunctionValidator(context, onConsumerRecord).validate();
     }
 
-    public void validateNonStanFunction(FunctionDefinitionNode functionDefinitionNode,
+    public void validateNonKafkaFunction(FunctionDefinitionNode functionDefinitionNode,
                                         SyntaxNodeAnalysisContext context) {
-        if (PluginUtils.isRemoteFunction(context, functionDefinitionNode)) {
-            context.reportDiagnostic(PluginUtils.getDiagnostic(CompilationErrors.INVALID_REMOTE_FUNCTION,
+        if (functionDefinitionNode.kind() == SyntaxKind.RESOURCE_ACCESSOR_DEFINITION) {
+            context.reportDiagnostic(PluginUtils.getDiagnostic(CompilationErrors.INVALID_FUNCTION,
                     DiagnosticSeverity.ERROR, functionDefinitionNode.location()));
+        } else {
+            if (PluginUtils.isRemoteFunction(context, functionDefinitionNode)) {
+                context.reportDiagnostic(PluginUtils.getDiagnostic(CompilationErrors.INVALID_REMOTE_FUNCTION,
+                        DiagnosticSeverity.ERROR, functionDefinitionNode.location()));
+            }
         }
     }
 

--- a/kafka-compiler-plugin/src/main/java/io/ballerina/stdlib/kafka/plugin/KafkaServiceValidator.java
+++ b/kafka-compiler-plugin/src/main/java/io/ballerina/stdlib/kafka/plugin/KafkaServiceValidator.java
@@ -39,17 +39,12 @@ import java.util.Optional;
  * Kafka service compilation validator.
  */
 public class KafkaServiceValidator {
-    private final SyntaxNodeAnalysisContext context;
-    private final NodeList<Node> memberNodes;
 
-    public KafkaServiceValidator(SyntaxNodeAnalysisContext context) {
-        this.context = context;
+    public void validate(SyntaxNodeAnalysisContext context) {
         ServiceDeclarationNode serviceDeclarationNode = (ServiceDeclarationNode) context.node();
-        this.memberNodes = serviceDeclarationNode.members();
-    }
+        NodeList<Node> memberNodes = serviceDeclarationNode.members();
 
-    public void validate() {
-        validateAnnotation(this.context);
+        validateAnnotation(context);
         FunctionDefinitionNode onConsumerRecord = null;
 
         for (Node node : memberNodes) {
@@ -61,7 +56,7 @@ public class KafkaServiceValidator {
                     if (functionName.get().equals(PluginConstants.ON_RECORDS_FUNC)) {
                         onConsumerRecord = functionDefinitionNode;
                     } else {
-                        validateNonStanFunction(functionDefinitionNode);
+                        validateNonStanFunction(functionDefinitionNode, context);
                     }
                 }
             }
@@ -69,7 +64,8 @@ public class KafkaServiceValidator {
         new KafkaFunctionValidator(context, onConsumerRecord).validate();
     }
 
-    public void validateNonStanFunction(FunctionDefinitionNode functionDefinitionNode) {
+    public void validateNonStanFunction(FunctionDefinitionNode functionDefinitionNode,
+                                        SyntaxNodeAnalysisContext context) {
         if (PluginUtils.isRemoteFunction(context, functionDefinitionNode)) {
             context.reportDiagnostic(PluginUtils.getDiagnostic(CompilationErrors.INVALID_REMOTE_FUNCTION,
                     DiagnosticSeverity.ERROR, functionDefinitionNode.location()));

--- a/kafka-compiler-plugin/src/main/java/io/ballerina/stdlib/kafka/plugin/PluginConstants.java
+++ b/kafka-compiler-plugin/src/main/java/io/ballerina/stdlib/kafka/plugin/PluginConstants.java
@@ -35,12 +35,6 @@ public class PluginConstants {
 
     // return types error or nil
     public static final String ERROR = "error";
-    public static final String KAFKA_ERROR = PACKAGE_PREFIX + ":" + ERROR_PARAM;
-    public static final String NIL = "?";
-    public static final String ERROR_OR_NIL = ERROR + NIL;
-    public static final String NIL_OR_ERROR = "()|" + ERROR;
-    public static final String KAFKA_ERROR_OR_NIL = KAFKA_ERROR + NIL;
-    public static final String NIL_OR_KAFKA_ERROR = "()|" + KAFKA_ERROR;
 
     /**
      * Compilation errors.
@@ -49,7 +43,8 @@ public class PluginConstants {
         NO_ON_CONSUMER_RECORD("Service must have remote method onConsumerRecord.",
                 "KAFKA_101"),
         INVALID_REMOTE_FUNCTION("Invalid remote method.", "KAFKA_102"),
-        FUNCTION_SHOULD_BE_REMOTE("Method must have the remote qualifier.", "KAFKA_103"),
+        INVALID_FUNCTION("Invalid remote method.", "KAFKA_103"),
+        FUNCTION_SHOULD_BE_REMOTE("Method must have the remote qualifier.", "KAFKA_104"),
         MUST_HAVE_CALLER_AND_RECORDS("Must have the method parameters kafka:Caller and kafka:ConsumerRecord[].",
                 "KAFKA_105"),
         INVALID_FUNCTION_PARAM_CALLER("Invalid method parameter. Only kafka:Caller is allowed.",

--- a/kafka-compiler-plugin/src/main/java/io/ballerina/stdlib/kafka/plugin/PluginConstants.java
+++ b/kafka-compiler-plugin/src/main/java/io/ballerina/stdlib/kafka/plugin/PluginConstants.java
@@ -46,17 +46,17 @@ public class PluginConstants {
      * Compilation errors.
      */
     enum CompilationErrors {
-        NO_ON_CONSUMER_RECORD("Service must have remote function onConsumerRecord.",
+        NO_ON_CONSUMER_RECORD("Service must have remote method onConsumerRecord.",
                 "KAFKA_101"),
-        INVALID_REMOTE_FUNCTION("Invalid remote function.", "KAFKA_102"),
-        FUNCTION_SHOULD_BE_REMOTE("Function must have the remote qualifier.", "KAFKA_103"),
-        MUST_HAVE_CALLER_AND_RECORDS("Must have the function parameters kafka:Caller and kafka:ConsumerRecord[].",
+        INVALID_REMOTE_FUNCTION("Invalid remote method.", "KAFKA_102"),
+        FUNCTION_SHOULD_BE_REMOTE("Method must have the remote qualifier.", "KAFKA_103"),
+        MUST_HAVE_CALLER_AND_RECORDS("Must have the method parameters kafka:Caller and kafka:ConsumerRecord[].",
                 "KAFKA_105"),
-        INVALID_FUNCTION_PARAM_CALLER("Invalid function parameter. Only kafka:Caller is allowed.",
+        INVALID_FUNCTION_PARAM_CALLER("Invalid method parameter. Only kafka:Caller is allowed.",
                 "KAFKA_106"),
-        INVALID_FUNCTION_PARAM_RECORDS("Invalid function parameter. Only kafka:ConsumerRecord[] is allowed.",
+        INVALID_FUNCTION_PARAM_RECORDS("Invalid method parameter. Only kafka:ConsumerRecord[] is allowed.",
                 "KAFKA_107"),
-        ONLY_PARAMS_ALLOWED("Invalid function parameter count. " +
+        ONLY_PARAMS_ALLOWED("Invalid method parameter count. " +
                 "Only kafka:Caller and kafka:ConsumerRecord[] are allowed.", "KAFKA_108"),
         INVALID_RETURN_TYPE_ERROR_OR_NIL("Invalid return type. Only error? or kafka:Error? is allowed.",
                 "KAFKA_109"),

--- a/kafka-compiler-plugin/src/main/java/io/ballerina/stdlib/kafka/plugin/PluginConstants.java
+++ b/kafka-compiler-plugin/src/main/java/io/ballerina/stdlib/kafka/plugin/PluginConstants.java
@@ -1,0 +1,87 @@
+/*
+ * Copyright (c) 2021, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package io.ballerina.stdlib.kafka.plugin;
+
+/**
+ * Kafka compiler plugin constants.
+ */
+public class PluginConstants {
+    // compiler plugin constants
+    public static final String PACKAGE_PREFIX = "kafka";
+    public static final String REMOTE_QUALIFIER = "REMOTE";
+    public static final String ON_RECORDS_FUNC = "onConsumerRecord";
+    public static final String PACKAGE_ORG = "ballerinax";
+
+    // parameters
+    public static final String CALLER = "Caller";
+    public static final String RECORD_PARAM = "ConsumerRecord";
+    public static final String ERROR_PARAM = "Error";
+
+    // return types error or nil
+    public static final String ERROR = "error";
+    public static final String KAFKA_ERROR = PACKAGE_PREFIX + ":" + ERROR_PARAM;
+    public static final String NIL = "?";
+    public static final String ERROR_OR_NIL = ERROR + NIL;
+    public static final String NIL_OR_ERROR = "()|" + ERROR;
+    public static final String KAFKA_ERROR_OR_NIL = KAFKA_ERROR + NIL;
+    public static final String NIL_OR_KAFKA_ERROR = "()|" + KAFKA_ERROR;
+
+    /**
+     * Compilation errors.
+     */
+    enum CompilationErrors {
+        NO_ON_CONSUMER_RECORD("Service must have remote function onConsumerRecord.",
+                "KAFKA_101"),
+        INVALID_REMOTE_FUNCTION("Invalid remote function.", "KAFKA_102"),
+        FUNCTION_SHOULD_BE_REMOTE("Function must have the remote qualifier.", "KAFKA_103"),
+        MUST_HAVE_CALLER_AND_RECORDS("Must have the function parameters kafka:Caller and kafka:ConsumerRecord[].",
+                "KAFKA_105"),
+        INVALID_FUNCTION_PARAM_CALLER("Invalid function parameter. Only kafka:Caller is allowed.",
+                "KAFKA_106"),
+        INVALID_FUNCTION_PARAM_RECORDS("Invalid function parameter. Only kafka:ConsumerRecord[] is allowed.",
+                "KAFKA_107"),
+        ONLY_PARAMS_ALLOWED("Invalid function parameter count. " +
+                "Only kafka:Caller and kafka:ConsumerRecord[] are allowed.", "KAFKA_108"),
+        INVALID_RETURN_TYPE_ERROR_OR_NIL("Invalid return type. Only error? or kafka:Error? is allowed.",
+                "KAFKA_109"),
+        INVALID_MULTIPLE_LISTENERS("Multiple listener attachments. Only one kafka:Listener is allowed.",
+                "KAFKA_110"),
+        INVALID_ANNOTATION_NUMBER("No annotations are allowed for kafka services.",
+                "KAFKA_111");
+
+        private final String error;
+        private final String errorCode;
+
+        CompilationErrors(String error, String errorCode) {
+            this.error = error;
+            this.errorCode = errorCode;
+        }
+
+        String getError() {
+            return error;
+        }
+
+        String getErrorCode() {
+            return errorCode;
+        }
+    }
+
+    private PluginConstants() {
+    }
+}

--- a/kafka-compiler-plugin/src/main/java/io/ballerina/stdlib/kafka/plugin/PluginUtils.java
+++ b/kafka-compiler-plugin/src/main/java/io/ballerina/stdlib/kafka/plugin/PluginUtils.java
@@ -65,9 +65,12 @@ public class PluginUtils {
     }
 
     public static boolean validateModuleId(ModuleSymbol moduleSymbol) {
-        String moduleName = moduleSymbol.id().moduleName();
-        String orgName = moduleSymbol.id().orgName();
-        return moduleName.equals(PluginConstants.PACKAGE_PREFIX) &&
-                orgName.equals(PluginConstants.PACKAGE_ORG);
+        if (moduleSymbol != null) {
+            String moduleName = moduleSymbol.id().moduleName();
+            String orgName = moduleSymbol.id().orgName();
+            return moduleName.equals(PluginConstants.PACKAGE_PREFIX) &&
+                    orgName.equals(PluginConstants.PACKAGE_ORG);
+        }
+        return false;
     }
 }

--- a/kafka-compiler-plugin/src/main/java/io/ballerina/stdlib/kafka/plugin/PluginUtils.java
+++ b/kafka-compiler-plugin/src/main/java/io/ballerina/stdlib/kafka/plugin/PluginUtils.java
@@ -20,6 +20,7 @@ package io.ballerina.stdlib.kafka.plugin;
 
 import io.ballerina.compiler.api.SemanticModel;
 import io.ballerina.compiler.api.symbols.MethodSymbol;
+import io.ballerina.compiler.api.symbols.ModuleSymbol;
 import io.ballerina.compiler.api.symbols.Qualifier;
 import io.ballerina.compiler.api.symbols.Symbol;
 import io.ballerina.compiler.syntax.tree.FunctionDefinitionNode;
@@ -60,6 +61,13 @@ public class PluginUtils {
     public static boolean isRemoteFunction(SyntaxNodeAnalysisContext context,
                                            FunctionDefinitionNode functionDefinitionNode) {
         MethodSymbol methodSymbol = getMethodSymbol(context, functionDefinitionNode);
-        return methodSymbol.qualifiers().contains(Qualifier.valueOf(PluginConstants.REMOTE_QUALIFIER));
+        return methodSymbol.qualifiers().contains(Qualifier.REMOTE);
+    }
+
+    public static boolean validateModuleId(ModuleSymbol moduleSymbol) {
+        String moduleName = moduleSymbol.id().moduleName();
+        String orgName = moduleSymbol.id().orgName();
+        return moduleName.equals(PluginConstants.PACKAGE_PREFIX) &&
+                orgName.equals(PluginConstants.PACKAGE_ORG);
     }
 }

--- a/kafka-compiler-plugin/src/main/java/io/ballerina/stdlib/kafka/plugin/PluginUtils.java
+++ b/kafka-compiler-plugin/src/main/java/io/ballerina/stdlib/kafka/plugin/PluginUtils.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright (c) 2021, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package io.ballerina.stdlib.kafka.plugin;
+
+import io.ballerina.compiler.api.SemanticModel;
+import io.ballerina.compiler.api.symbols.MethodSymbol;
+import io.ballerina.compiler.api.symbols.Qualifier;
+import io.ballerina.compiler.api.symbols.Symbol;
+import io.ballerina.compiler.syntax.tree.FunctionDefinitionNode;
+import io.ballerina.projects.plugins.SyntaxNodeAnalysisContext;
+import io.ballerina.tools.diagnostics.Diagnostic;
+import io.ballerina.tools.diagnostics.DiagnosticFactory;
+import io.ballerina.tools.diagnostics.DiagnosticInfo;
+import io.ballerina.tools.diagnostics.DiagnosticSeverity;
+import io.ballerina.tools.diagnostics.Location;
+
+import java.util.Optional;
+
+/**
+ * Util class for the compiler plugin.
+ */
+public class PluginUtils {
+
+    public static Diagnostic getDiagnostic(PluginConstants.CompilationErrors error, DiagnosticSeverity severity,
+                                           Location location) {
+        String errorMessage = error.getError();
+        String diagnosticCode = error.getErrorCode();
+        DiagnosticInfo diagnosticInfo = new DiagnosticInfo(diagnosticCode, errorMessage,
+                severity);
+        return DiagnosticFactory.createDiagnostic(diagnosticInfo, location);
+    }
+
+    public static MethodSymbol getMethodSymbol(SyntaxNodeAnalysisContext context,
+                                               FunctionDefinitionNode functionDefinitionNode) {
+        MethodSymbol methodSymbol = null;
+        SemanticModel semanticModel = context.semanticModel();
+        Optional<Symbol> symbol = semanticModel.symbol(functionDefinitionNode);
+        if (symbol.isPresent()) {
+            methodSymbol = (MethodSymbol) symbol.get();
+        }
+        return methodSymbol;
+    }
+
+    public static boolean isRemoteFunction(SyntaxNodeAnalysisContext context,
+                                           FunctionDefinitionNode functionDefinitionNode) {
+        MethodSymbol methodSymbol = getMethodSymbol(context, functionDefinitionNode);
+        return methodSymbol.qualifiers().contains(Qualifier.valueOf(PluginConstants.REMOTE_QUALIFIER));
+    }
+}

--- a/kafka-compiler-plugin/src/main/java/module-info.java
+++ b/kafka-compiler-plugin/src/main/java/module-info.java
@@ -1,0 +1,23 @@
+/*
+ * Copyright (c) 2021 WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+module io.ballerina.stdlib.kafka.plugin {
+    requires io.ballerina.lang;
+    requires io.ballerina.parser;
+    requires io.ballerina.tools.api;
+}

--- a/kafka-native/src/main/java/module-info.java
+++ b/kafka-native/src/main/java/module-info.java
@@ -16,7 +16,7 @@
  * under the License.
  */
 
-module io.ballerina.stdlib.kafka {
+module io.ballerina.stdlib.kafka.runtime {
     requires kafka.clients;
     requires io.ballerina.runtime;
     requires java.transaction.xa;

--- a/settings.gradle
+++ b/settings.gradle
@@ -13,7 +13,7 @@ plugins {
 
 rootProject.name = 'kafka'
 include(':build-config:checkstyle')
-include ':kafka-native', ':kafka-ballerina'
+include ':kafka-ballerina', 'kafka-native', 'kafka-compiler-plugin', 'kafka-compiler-plugin-tests'
 
 gradleEnterprise {
     buildScan {


### PR DESCRIPTION
Fixes: https://github.com/ballerina-platform/ballerina-standard-library/issues/1237

## Rules
- Only Kafka services are validated 
- Only one listener is allowed per service 
- No annotations are allowed 
- Service must have the remote method `onConsumerRecord`
- Service cannot have any other remote methods

### onConsumerRecord
- Must have first parameter `kafka:Caller`
```ballerina
// valid
remote function onConsumerRecord(kafka:Caller caller, kafka:ConsumerRecord[] records) {}
// invalid
remote function onConsumerRecord(kafka:Consumer caller, kafka:ConsumerRecord[] records) {}
remote function onConsumerRecord(string caller, kafka:ConsumerRecord[] records) {}
remote function onConsumerRecord() {}
remote function onConsumerRecord(kafka:ConsumerRecord[] records) {}
```
- Cannote have more than two parameters
```ballerina
// invalid
remote function onConsumerRecord(kafka:Caller caller, kafka:ConsumerRecord[] records, string something) {}
```
- `onConsumerRecord` can only have return values `error?` or `kafka:Error?`
```ballerina
// valid
remote function onConsumerRecord(kafka:Caller caller, kafka:ConsumerRecord[] records) returns error? {}
// invalid
remote function onConsumerRecord(kafka:Caller caller, kafka:ConsumerRecord[] records) returns string {}
remote function onConsumerRecord(kafka:Caller caller, kafka:ConsumerRecord[] records) returns kafka:Caller {}
```
- `onConsumerRecord` can have no return value too

## Checklist
- [x] Linked to an issue
- [ ] Updated the changelog
- [x] Added tests
