### PR TITLE
Update flag for coverage format

### DIFF
--- a/kafka-ballerina/build.gradle
+++ b/kafka-ballerina/build.gradle
@@ -64,7 +64,7 @@ ballerina {
     module = packageName
     langVersion = ballerinaLangVersion
     packageOrganization = packageOrg
-    testCoverageParam = "--code-coverage --jacoco-xml --includes=*"
+    testCoverageParam = "--code-coverage --coverage-format=xml --includes=*"
 }
 
 configurations {


### PR DESCRIPTION
## Purpose
Update flag for coverage format from '--jacoco-xml' to '--coverage-format=xml'

## Examples

## Checklist
- [ ] Linked to an issue
- [ ] Updated the changelog
- [ ] Added tests