### PR TITLE
Remove unnecessary print statements

### DIFF
--- a/kafka-native/src/main/java/org/ballerinalang/messaging/kafka/nativeimpl/consumer/BrokerConnection.java
+++ b/kafka-native/src/main/java/org/ballerinalang/messaging/kafka/nativeimpl/consumer/BrokerConnection.java
@@ -34,7 +34,6 @@ import org.ballerinalang.messaging.kafka.utils.KafkaConstants;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.io.PrintStream;
 import java.time.Duration;
 import java.util.ArrayList;
 import java.util.Objects;
@@ -63,7 +62,6 @@ import static org.ballerinalang.messaging.kafka.utils.KafkaUtils.processKafkaCon
 public class BrokerConnection {
 
     private static final Logger logger = LoggerFactory.getLogger(BrokerConnection.class);
-    private static final PrintStream console = System.out;
 
     /**
      * Closes the connection between ballerina kafka consumer and the kafka broker.
@@ -124,7 +122,9 @@ public class BrokerConnection {
             KafkaMetricsUtil.reportConsumerError(consumerObject, KafkaObservabilityConstants.ERROR_TYPE_CONNECTION);
             return createKafkaError("Cannot connect to the kafka server: " + e.getMessage());
         }
-        console.println(KAFKA_SERVERS + getServerUrls(bootStrapServers));
+        if (logger.isDebugEnabled()) {
+            logger.debug(KAFKA_SERVERS + getServerUrls(bootStrapServers));
+        }
         return null;
     }
 

--- a/kafka-native/src/main/java/org/ballerinalang/messaging/kafka/nativeimpl/consumer/SubscriptionHandler.java
+++ b/kafka-native/src/main/java/org/ballerinalang/messaging/kafka/nativeimpl/consumer/SubscriptionHandler.java
@@ -58,6 +58,7 @@ public class SubscriptionHandler {
         KafkaTracingUtil.traceResourceInvocation(environment, consumerObject);
         KafkaConsumer kafkaConsumer = (KafkaConsumer) consumerObject.getNativeData(NATIVE_CONSUMER);
         List<String> topicsList = getStringListFromStringBArray(topics);
+        consumerObject.addNativeData("topics", topicsList);
         try {
             kafkaConsumer.subscribe(topicsList);
             Set<String> subscribedTopics = kafkaConsumer.subscription();

--- a/kafka-native/src/main/java/org/ballerinalang/messaging/kafka/nativeimpl/consumer/SubscriptionHandler.java
+++ b/kafka-native/src/main/java/org/ballerinalang/messaging/kafka/nativeimpl/consumer/SubscriptionHandler.java
@@ -28,8 +28,9 @@ import org.ballerinalang.messaging.kafka.observability.KafkaMetricsUtil;
 import org.ballerinalang.messaging.kafka.observability.KafkaObservabilityConstants;
 import org.ballerinalang.messaging.kafka.observability.KafkaTracingUtil;
 import org.ballerinalang.messaging.kafka.utils.KafkaConstants;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
-import java.io.PrintStream;
 import java.util.List;
 import java.util.Set;
 import java.util.regex.Pattern;
@@ -43,7 +44,8 @@ import static org.ballerinalang.messaging.kafka.utils.KafkaUtils.getTopicNamesSt
  * Native methods to handle subscription of the ballerina kafka consumer.
  */
 public class SubscriptionHandler {
-    private static final PrintStream console = System.out;
+
+    private static final Logger logger = LoggerFactory.getLogger(SubscriptionHandler.class);
 
     /**
      * Subscribe the ballerina kafka consumer to the given array of topics.
@@ -64,7 +66,9 @@ public class SubscriptionHandler {
             KafkaMetricsUtil.reportConsumerError(consumerObject, KafkaObservabilityConstants.ERROR_TYPE_SUBSCRIBE);
             return createKafkaError("Failed to subscribe to the provided topics: " + e.getMessage());
         }
-        console.println(KafkaConstants.SUBSCRIBED_TOPICS + getTopicNamesString(topicsList));
+        if (logger.isDebugEnabled()) {
+            logger.debug(KafkaConstants.SUBSCRIBED_TOPICS + getTopicNamesString(topicsList));
+        }
         return null;
     }
 

--- a/kafka-native/src/main/java/org/ballerinalang/messaging/kafka/service/Start.java
+++ b/kafka-native/src/main/java/org/ballerinalang/messaging/kafka/service/Start.java
@@ -24,9 +24,11 @@ import org.ballerinalang.messaging.kafka.impl.KafkaServerConnectorImpl;
 import org.ballerinalang.messaging.kafka.utils.KafkaUtils;
 
 import java.io.PrintStream;
+import java.util.List;
 
 import static org.ballerinalang.messaging.kafka.utils.KafkaConstants.SERVER_CONNECTOR;
 import static org.ballerinalang.messaging.kafka.utils.KafkaConstants.SERVICE_STARTED;
+import static org.ballerinalang.messaging.kafka.utils.KafkaUtils.getTopicNamesString;
 
 /**
  * Start server connector.
@@ -38,7 +40,7 @@ public class Start {
         KafkaServerConnectorImpl serverConnector = (KafkaServerConnectorImpl) listener.getNativeData(SERVER_CONNECTOR);
         try {
             serverConnector.start();
-            console.println(SERVICE_STARTED);
+            console.println(SERVICE_STARTED + getTopicNamesString((List<String>) listener.getNativeData("topics")));
         } catch (KafkaConnectorException e) {
             return KafkaUtils.createKafkaError(e.getMessage());
         }

--- a/kafka-native/src/main/java/org/ballerinalang/messaging/kafka/utils/KafkaConstants.java
+++ b/kafka-native/src/main/java/org/ballerinalang/messaging/kafka/utils/KafkaConstants.java
@@ -34,8 +34,8 @@ public class KafkaConstants {
     public static final int DURATION_UNDEFINED_VALUE = -1;
 
     // Kafka log messages
-    public static final String SERVICE_STARTED = "[ballerinax/kafka] started kafka listener for topic/s ";
-    public static final String SERVICE_STOPPED = "[ballerinax/kafka] stopped kafka listener ";
+    public static final String SERVICE_STARTED = "[ballerinax/kafka] Kafka listener started for topics: ";
+    public static final String SERVICE_STOPPED = "[ballerinax/kafka] Kafka listener stopped ";
     public static final String KAFKA_SERVERS = "[ballerinax/kafka] kafka servers: ";
     public static final String SUBSCRIBED_TOPICS = "[ballerinax/kafka] subscribed topics: ";
 

--- a/kafka-native/src/main/java/org/ballerinalang/messaging/kafka/utils/KafkaConstants.java
+++ b/kafka-native/src/main/java/org/ballerinalang/messaging/kafka/utils/KafkaConstants.java
@@ -34,7 +34,7 @@ public class KafkaConstants {
     public static final int DURATION_UNDEFINED_VALUE = -1;
 
     // Kafka log messages
-    public static final String SERVICE_STARTED = "[ballerinax/kafka] started kafka listener ";
+    public static final String SERVICE_STARTED = "[ballerinax/kafka] started kafka listener for topic/s ";
     public static final String SERVICE_STOPPED = "[ballerinax/kafka] stopped kafka listener ";
     public static final String KAFKA_SERVERS = "[ballerinax/kafka] kafka servers: ";
     public static final String SUBSCRIBED_TOPICS = "[ballerinax/kafka] subscribed topics: ";


### PR DESCRIPTION
## Purpose
Remove print statements in client startup
## Examples
N/A
## Checklist
- [ ] Linked to an issue
- [ ] Updated the changelog
- [ ] Added tests
