### PR TITLE
Fix the concurrent modification exception when kafka listener is initialized outside of a main function

### DIFF
--- a/ballerina/Dependencies.toml
+++ b/ballerina/Dependencies.toml
@@ -8,9 +8,33 @@ dependencies-toml-version = "2"
 
 [[package]]
 org = "ballerina"
+name = "auth"
+version = "2.0.0"
+scope = "testOnly"
+dependencies = [
+	{org = "ballerina", name = "crypto"},
+	{org = "ballerina", name = "jballerina.java"},
+	{org = "ballerina", name = "lang.array"},
+	{org = "ballerina", name = "lang.string"},
+	{org = "ballerina", name = "log"},
+	{org = "ballerina", name = "regex"}
+]
+
+[[package]]
+org = "ballerina"
+name = "cache"
+version = "3.0.0"
+scope = "testOnly"
+dependencies = [
+	{org = "ballerina", name = "jballerina.java"},
+	{org = "ballerina", name = "task"},
+	{org = "ballerina", name = "time"}
+]
+
+[[package]]
+org = "ballerina"
 name = "crypto"
 version = "2.0.0"
-transitive = false
 dependencies = [
 	{org = "ballerina", name = "jballerina.java"},
 	{org = "ballerina", name = "time"}
@@ -21,27 +45,220 @@ modules = [
 
 [[package]]
 org = "ballerina"
+name = "file"
+version = "1.0.0"
+scope = "testOnly"
+dependencies = [
+	{org = "ballerina", name = "jballerina.java"},
+	{org = "ballerina", name = "log"},
+	{org = "ballerina", name = "os"},
+	{org = "ballerina", name = "regex"},
+	{org = "ballerina", name = "time"}
+]
+
+[[package]]
+org = "ballerina"
+name = "http"
+version = "2.0.0"
+scope = "testOnly"
+dependencies = [
+	{org = "ballerina", name = "auth"},
+	{org = "ballerina", name = "cache"},
+	{org = "ballerina", name = "crypto"},
+	{org = "ballerina", name = "file"},
+	{org = "ballerina", name = "io"},
+	{org = "ballerina", name = "jballerina.java"},
+	{org = "ballerina", name = "jwt"},
+	{org = "ballerina", name = "lang.array"},
+	{org = "ballerina", name = "lang.decimal"},
+	{org = "ballerina", name = "lang.int"},
+	{org = "ballerina", name = "lang.runtime"},
+	{org = "ballerina", name = "lang.string"},
+	{org = "ballerina", name = "lang.value"},
+	{org = "ballerina", name = "log"},
+	{org = "ballerina", name = "mime"},
+	{org = "ballerina", name = "oauth2"},
+	{org = "ballerina", name = "observe"},
+	{org = "ballerina", name = "regex"},
+	{org = "ballerina", name = "time"},
+	{org = "ballerina", name = "url"}
+]
+
+[[package]]
+org = "ballerina"
+name = "io"
+version = "1.0.0"
+scope = "testOnly"
+dependencies = [
+	{org = "ballerina", name = "jballerina.java"},
+	{org = "ballerina", name = "lang.value"}
+]
+modules = [
+	{org = "ballerina", packageName = "io", moduleName = "io"}
+]
+
+[[package]]
+org = "ballerina"
 name = "jballerina.java"
-version = "0.9.0"
-transitive = false
+version = "0.0.0"
 modules = [
 	{org = "ballerina", packageName = "jballerina.java", moduleName = "jballerina.java"}
 ]
 
 [[package]]
 org = "ballerina"
-name = "lang.int"
-version = "1.1.0"
-transitive = true
+name = "jwt"
+version = "2.0.0"
+scope = "testOnly"
+dependencies = [
+	{org = "ballerina", name = "cache"},
+	{org = "ballerina", name = "crypto"},
+	{org = "ballerina", name = "jballerina.java"},
+	{org = "ballerina", name = "lang.int"},
+	{org = "ballerina", name = "lang.string"},
+	{org = "ballerina", name = "log"},
+	{org = "ballerina", name = "regex"},
+	{org = "ballerina", name = "time"}
+]
+
+[[package]]
+org = "ballerina"
+name = "lang.__internal"
+version = "0.0.0"
+scope = "testOnly"
+dependencies = [
+	{org = "ballerina", name = "jballerina.java"},
+	{org = "ballerina", name = "lang.object"}
+]
+
+[[package]]
+org = "ballerina"
+name = "lang.array"
+version = "0.0.0"
+scope = "testOnly"
+dependencies = [
+	{org = "ballerina", name = "jballerina.java"},
+	{org = "ballerina", name = "lang.__internal"}
+]
+
+[[package]]
+org = "ballerina"
+name = "lang.decimal"
+version = "0.0.0"
+scope = "testOnly"
 dependencies = [
 	{org = "ballerina", name = "jballerina.java"}
 ]
 
 [[package]]
 org = "ballerina"
+name = "lang.int"
+version = "0.0.0"
+dependencies = [
+	{org = "ballerina", name = "jballerina.java"}
+]
+
+[[package]]
+org = "ballerina"
+name = "lang.object"
+version = "0.0.0"
+scope = "testOnly"
+
+[[package]]
+org = "ballerina"
+name = "lang.runtime"
+version = "0.0.0"
+scope = "testOnly"
+dependencies = [
+	{org = "ballerina", name = "jballerina.java"},
+	{org = "ballerina", name = "lang.array"},
+	{org = "ballerina", name = "lang.value"}
+]
+modules = [
+	{org = "ballerina", packageName = "lang.runtime", moduleName = "lang.runtime"}
+]
+
+[[package]]
+org = "ballerina"
+name = "lang.string"
+version = "0.0.0"
+scope = "testOnly"
+dependencies = [
+	{org = "ballerina", name = "jballerina.java"}
+]
+modules = [
+	{org = "ballerina", packageName = "lang.string", moduleName = "lang.string"}
+]
+
+[[package]]
+org = "ballerina"
+name = "lang.transaction"
+version = "0.0.0"
+scope = "testOnly"
+dependencies = [
+	{org = "ballerina", name = "jballerina.java"}
+]
+
+[[package]]
+org = "ballerina"
+name = "lang.value"
+version = "0.0.0"
+scope = "testOnly"
+dependencies = [
+	{org = "ballerina", name = "jballerina.java"}
+]
+
+[[package]]
+org = "ballerina"
+name = "log"
+version = "2.0.0"
+scope = "testOnly"
+dependencies = [
+	{org = "ballerina", name = "io"},
+	{org = "ballerina", name = "jballerina.java"},
+	{org = "ballerina", name = "observe"}
+]
+modules = [
+	{org = "ballerina", packageName = "log", moduleName = "log"}
+]
+
+[[package]]
+org = "ballerina"
+name = "mime"
+version = "2.0.0"
+scope = "testOnly"
+dependencies = [
+	{org = "ballerina", name = "io"},
+	{org = "ballerina", name = "jballerina.java"},
+	{org = "ballerina", name = "lang.int"}
+]
+
+[[package]]
+org = "ballerina"
+name = "oauth2"
+version = "2.0.0"
+scope = "testOnly"
+dependencies = [
+	{org = "ballerina", name = "cache"},
+	{org = "ballerina", name = "crypto"},
+	{org = "ballerina", name = "jballerina.java"},
+	{org = "ballerina", name = "log"},
+	{org = "ballerina", name = "time"}
+]
+
+[[package]]
+org = "ballerina"
 name = "observe"
 version = "0.9.0"
-transitive = true
+dependencies = [
+	{org = "ballerina", name = "jballerina.java"}
+]
+
+[[package]]
+org = "ballerina"
+name = "os"
+version = "1.0.0"
+scope = "testOnly"
 dependencies = [
 	{org = "ballerina", name = "jballerina.java"}
 ]
@@ -50,16 +267,45 @@ dependencies = [
 org = "ballerina"
 name = "regex"
 version = "1.0.0"
-transitive = true
 dependencies = [
 	{org = "ballerina", name = "jballerina.java"}
 ]
 
 [[package]]
 org = "ballerina"
+name = "task"
+version = "2.0.0"
+scope = "testOnly"
+dependencies = [
+	{org = "ballerina", name = "jballerina.java"},
+	{org = "ballerina", name = "time"}
+]
+
+[[package]]
+org = "ballerina"
+name = "test"
+version = "0.0.0"
+scope = "testOnly"
+dependencies = [
+	{org = "ballerina", name = "jballerina.java"}
+]
+modules = [
+	{org = "ballerina", packageName = "test", moduleName = "test"}
+]
+
+[[package]]
+org = "ballerina"
 name = "time"
 version = "2.0.0"
-transitive = true
+dependencies = [
+	{org = "ballerina", name = "jballerina.java"}
+]
+
+[[package]]
+org = "ballerina"
+name = "url"
+version = "2.0.0"
+scope = "testOnly"
 dependencies = [
 	{org = "ballerina", name = "jballerina.java"}
 ]
@@ -68,7 +314,6 @@ dependencies = [
 org = "ballerina"
 name = "uuid"
 version = "1.0.0"
-transitive = false
 dependencies = [
 	{org = "ballerina", name = "crypto"},
 	{org = "ballerina", name = "jballerina.java"},
@@ -82,14 +327,55 @@ modules = [
 [[package]]
 org = "ballerinai"
 name = "observe"
-version = "0.9.0"
-transitive = false
+version = "0.0.0"
 dependencies = [
 	{org = "ballerina", name = "jballerina.java"},
 	{org = "ballerina", name = "observe"}
 ]
 modules = [
 	{org = "ballerinai", packageName = "observe", moduleName = "observe"}
+]
+
+[[package]]
+org = "ballerinai"
+name = "transaction"
+version = "0.0.0"
+scope = "testOnly"
+dependencies = [
+	{org = "ballerina", name = "cache"},
+	{org = "ballerina", name = "http"},
+	{org = "ballerina", name = "io"},
+	{org = "ballerina", name = "jballerina.java"},
+	{org = "ballerina", name = "lang.runtime"},
+	{org = "ballerina", name = "lang.transaction"},
+	{org = "ballerina", name = "lang.value"},
+	{org = "ballerina", name = "log"},
+	{org = "ballerina", name = "task"},
+	{org = "ballerina", name = "time"},
+	{org = "ballerina", name = "uuid"}
+]
+modules = [
+	{org = "ballerinai", packageName = "transaction", moduleName = "transaction"}
+]
+
+[[package]]
+org = "ballerinax"
+name = "kafka"
+version = "3.0.0"
+dependencies = [
+	{org = "ballerina", name = "crypto"},
+	{org = "ballerina", name = "io"},
+	{org = "ballerina", name = "jballerina.java"},
+	{org = "ballerina", name = "lang.runtime"},
+	{org = "ballerina", name = "lang.string"},
+	{org = "ballerina", name = "log"},
+	{org = "ballerina", name = "test"},
+	{org = "ballerina", name = "uuid"},
+	{org = "ballerinai", name = "observe"},
+	{org = "ballerinai", name = "transaction"}
+]
+modules = [
+	{org = "ballerinax", packageName = "kafka", moduleName = "kafka"}
 ]
 
 

--- a/ballerina/tests/consumer_client_tests.bal
+++ b/ballerina/tests/consumer_client_tests.bal
@@ -61,7 +61,7 @@ ProducerConfiguration producerConfiguration = {
 };
 Producer producer = check new (DEFAULT_URL, producerConfiguration);
 
-@test:Config {}
+@test:Config { groups: ["consumer"] }
 function consumerCloseTest() returns error? {
     string topic = "close-test-topic";
     check sendMessage(TEST_MESSAGE.toBytes(), topic);
@@ -82,7 +82,7 @@ function consumerCloseTest() returns error? {
     test:assertEquals(receivedErr.message(), expectedErr);
 }
 
-@test:Config {}
+@test:Config { groups: ["consumer"] }
 function consumerCloseWithDurationTest() returns error? {
     string topic = "close-with-duration-test-topic";
     ConsumerConfiguration consumerConfiguration = {
@@ -102,7 +102,7 @@ function consumerCloseWithDurationTest() returns error? {
     test:assertEquals(receivedErr.message(), expectedErr);
 }
 
-@test:Config {}
+@test:Config { groups: ["consumer"] }
 function consumerCloseWithDefaultTimeoutTest() returns error? {
     string topic = "close-with-default-timeout-test-topic";
     ConsumerConfiguration consumerConfiguration = {
@@ -123,7 +123,7 @@ function consumerCloseWithDefaultTimeoutTest() returns error? {
     test:assertEquals(receivedErr.message(), expectedErr);
 }
 
-@test:Config {}
+@test:Config { groups: ["consumer"] }
 function consumerConfigTest() returns error? {
     string topic = "consumer-config-test-topic";
     ConsumerConfiguration consumerConfiguration = {
@@ -143,7 +143,7 @@ function consumerConfigTest() returns error? {
     check consumer->close();
 }
 
-@test:Config {}
+@test:Config { groups: ["consumer"] }
 function consumerFunctionsTest() returns error? {
     string topic = "consumer-functions-test-topic";
     check sendMessage(TEST_MESSAGE.toBytes(), topic);
@@ -162,7 +162,7 @@ function consumerFunctionsTest() returns error? {
     check consumer->close();
 }
 
-@test:Config {}
+@test:Config { groups: ["consumer"] }
 function consumerSeekTest() returns error? {
     string topic = "consumer-seek-test-topic";
     check sendMessage(TEST_MESSAGE.toBytes(), topic);
@@ -201,7 +201,7 @@ function consumerSeekTest() returns error? {
     check consumer->close();
 }
 
-@test:Config {}
+@test:Config { groups: ["consumer"] }
 function consumerSeekToBeginningTest() returns error? {
     string topic = "consumer-seek-to-beginning-test-topic";
     check sendMessage(TEST_MESSAGE.toBytes(), topic);
@@ -233,7 +233,7 @@ function consumerSeekToBeginningTest() returns error? {
     check consumer->close();
 }
 
-@test:Config {}
+@test:Config { groups: ["consumer"] }
 function consumerSeekToEndTest() returns error? {
     string topic = "consumer-seek-to-end-test-topic";
     check sendMessage(TEST_MESSAGE.toBytes(), topic);
@@ -266,7 +266,7 @@ function consumerSeekToEndTest() returns error? {
     check consumer->close();
 }
 
-@test:Config {}
+@test:Config { groups: ["consumer"] }
 function consumerSeekToNegativeValueTest() returns error? {
     string topic = "consumer-seek-negative-value-test-topic";
     ConsumerConfiguration consumerConfiguration = {
@@ -295,7 +295,8 @@ function consumerSeekToNegativeValueTest() returns error? {
 }
 
 @test:Config {
-    dependsOn: [consumerSeekTest, consumerSeekToBeginningTest, consumerSeekToEndTest]
+    dependsOn: [consumerSeekTest, consumerSeekToBeginningTest, consumerSeekToEndTest],
+    groups: ["consumer"]
 }
 function consumerPositionOffsetsTest() returns error? {
     string topic = "consumer-position-offsets-test-topic";
@@ -334,7 +335,8 @@ function consumerPositionOffsetsTest() returns error? {
 }
 
 @test:Config {
-    dependsOn: [consumerSeekTest, consumerSeekToBeginningTest, consumerSeekToEndTest]
+    dependsOn: [consumerSeekTest, consumerSeekToBeginningTest, consumerSeekToEndTest],
+    groups: ["consumer"]
 }
 function consumerBeginningOffsetsTest() returns error? {
     string topic = "consumer-beginning-offsets-test-topic";
@@ -386,7 +388,8 @@ function consumerBeginningOffsetsTest() returns error? {
 }
 
 @test:Config {
-    dependsOn: [consumerSeekTest, consumerSeekToBeginningTest, consumerSeekToEndTest]
+    dependsOn: [consumerSeekTest, consumerSeekToBeginningTest, consumerSeekToEndTest],
+    groups: ["consumer"]
 }
 function consumerEndOffsetsTest() returns error? {
     string topic = "consumer-end-offsets-test-topic";
@@ -435,7 +438,7 @@ function consumerEndOffsetsTest() returns error? {
     check consumer->close();
 }
 
-@test:Config {}
+@test:Config { groups: ["consumer"] }
 function consumerTopicPartitionsTest() returns error? {
     string topic1 = "consumer-topic-partitions-test-topic-1";
     string topic2 = "consumer-topic-partitions-test-topic-2";
@@ -464,7 +467,7 @@ function consumerTopicPartitionsTest() returns error? {
     check consumer->close();
 }
 
-@test:Config {}
+@test:Config { groups: ["consumer"] }
 function consumerPauseResumePartitionTest() returns error? {
     string topic = "consumer-pause-resume-partition-test-topic";
     ConsumerConfiguration consumerConfiguration = {
@@ -495,7 +498,7 @@ function consumerPauseResumePartitionTest() returns error? {
     check consumer->close();
 }
 
-@test:Config {}
+@test:Config { groups: ["consumer"] }
 function consumerPauseResumePartitionErrorTest() returns error? {
     string topic1 = "consumer-pause-resume-partition-error-test-topic-1";
     string topic2 = "consumer-pause-resume-partition-error-test-topic-2";
@@ -537,7 +540,7 @@ function consumerPauseResumePartitionErrorTest() returns error? {
     check consumer->close();
 }
 
-@test:Config {}
+@test:Config { groups: ["consumer"] }
 function consumerAssignToEmptyTopicTest() returns error? {
     ConsumerConfiguration consumerConfiguration = {
         offsetReset: OFFSET_RESET_EARLIEST,
@@ -559,7 +562,7 @@ function consumerAssignToEmptyTopicTest() returns error? {
     check consumer->close();
 }
 
-@test:Config {}
+@test:Config { groups: ["consumer"] }
 function consumerGetAssignedPartitionsTest() returns error? {
     string topic = "consumer-assigned-partitions-test-topic";
     ConsumerConfiguration consumerConfiguration = {
@@ -581,7 +584,8 @@ function consumerGetAssignedPartitionsTest() returns error? {
 }
 
 @test:Config {
-    dependsOn: [consumerFunctionsTest]
+    dependsOn: [consumerFunctionsTest],
+    groups: ["consumer"]
 }
 function consumerSubscribeUnsubscribeTest() returns error? {
     string topic1 = "consumer-subscribe-unsubscribe-test-topic-1";
@@ -601,9 +605,7 @@ function consumerSubscribeUnsubscribeTest() returns error? {
     check consumer->close();
 }
 
-@test:Config {
-    dependsOn: [consumerFunctionsTest, consumerServiceTest, producerSendStringTest, manualCommitTest]
-}
+@test:AfterGroups { value:["consumer", "producer", "listener"] }
 function consumerSubscribeTest() returns error? {
     Consumer consumer = check new (DEFAULT_URL, {
         groupId: "consumer-subscriber-test-group",
@@ -611,17 +613,17 @@ function consumerSubscribeTest() returns error? {
         metadataMaxAge: 2
     });
     string[] availableTopics = check consumer->getAvailableTopics();
-    test:assertEquals(availableTopics.length(), 31);
+    test:assertEquals(availableTopics.length(), 52);
     string[] subscribedTopics = check consumer->getSubscription();
     test:assertEquals(subscribedTopics.length(), 0);
     check consumer->subscribeWithPattern("consumer.*");
     ConsumerRecord[] pollResult = check consumer->poll(1); // Polling to force-update the metadata
     string[] newSubscribedTopics = check consumer->getSubscription();
-    test:assertEquals(newSubscribedTopics.length(), 10);
+    test:assertEquals(newSubscribedTopics.length(), 12);
     check consumer->close();
 }
 
-@test:Config {}
+@test:Config { groups: ["consumer"] }
 function consumerSubscribeWithPatternToClosedConsumerTest() returns error? {
     Consumer consumer = check new (DEFAULT_URL, {
         groupId: "consumer-subscribe-closed-consumer-group",
@@ -638,7 +640,7 @@ function consumerSubscribeWithPatternToClosedConsumerTest() returns error? {
     }
 }
 
-@test:Config {}
+@test:Config { groups: ["consumer"] }
 function consumerSubscribeToEmptyTopicTest() returns error? {
     Consumer consumer = check new (DEFAULT_URL, {
         groupId: "consumer-subscribe-empty-topic-test-group",
@@ -656,7 +658,7 @@ function consumerSubscribeToEmptyTopicTest() returns error? {
     check consumer->close();
 }
 
-@test:Config {}
+@test:AfterGroups { value:["consumer", "producer", "listener"] }
 function consumerTopicsAvailableWithTimeoutTest() returns error? {
     Consumer consumer = check new (DEFAULT_URL, {
         groupId: "consumer-topics-available-timeout-test-group-1",
@@ -664,7 +666,7 @@ function consumerTopicsAvailableWithTimeoutTest() returns error? {
         metadataMaxAge: 2
     });
     string[] availableTopics = check consumer->getAvailableTopics(TIMEOUT_DURATION);
-    test:assertEquals(availableTopics.length(), 33);
+    test:assertEquals(availableTopics.length(), 52);
     check consumer->close();
 
     consumer = check new (DEFAULT_URL, {
@@ -674,12 +676,13 @@ function consumerTopicsAvailableWithTimeoutTest() returns error? {
         defaultApiTimeout: DEFAULT_TIMEOUT
     });
     availableTopics = check consumer->getAvailableTopics();
-    test:assertEquals(availableTopics.length(), 33);
+    test:assertEquals(availableTopics.length(), 52);
     check consumer->close();
 }
 
 @test:Config {
-    dependsOn: [consumerFunctionsTest]
+    dependsOn: [consumerFunctionsTest],
+    groups: ["consumer"]
 }
 function consumerSubscribeErrorTest() returns error? {
     string topic = "consumer-subsribe-error-test-topic";
@@ -697,7 +700,7 @@ function consumerSubscribeErrorTest() returns error? {
     check consumer->close();
 }
 
-@test:Config {}
+@test:Config { groups: ["consumer"] }
 function manualCommitTest() returns error? {
     string topic = "manual-commit-test-topic";
     ConsumerConfiguration consumerConfiguration = {
@@ -741,7 +744,7 @@ function manualCommitTest() returns error? {
     check consumer->close();
 }
 
-@test:Config {}
+@test:Config { groups: ["consumer"] }
 function manualCommitWithDurationTest() returns error? {
     string topic = "manual-commit-with-duration-test-topic";
     ConsumerConfiguration consumerConfiguration = {
@@ -771,7 +774,7 @@ function manualCommitWithDurationTest() returns error? {
     check consumer->close();
 }
 
-@test:Config {}
+@test:Config { groups: ["consumer"] }
 function manualCommitWithDefaultTimeoutTest() returns error? {
     string topic = "manual-commit-with-default-timeout-test-topic";
     ConsumerConfiguration consumerConfiguration = {
@@ -802,7 +805,7 @@ function manualCommitWithDefaultTimeoutTest() returns error? {
     check consumer->close();
 }
 
-@test:Config {}
+@test:Config { groups: ["consumer"] }
 function nonExistingTopicPartitionOffsetsTest() returns error? {
     string existingTopic = "existing-test-topic";
     ConsumerConfiguration consumerConfiguration = {
@@ -906,7 +909,7 @@ function consumerAdditionalPropertiesTest() returns error? {
     check consumer->close();
 }
 
-@test:Config {}
+@test:Config { groups: ["consumer"] }
 function sslKeystoreConsumerTest() returns error? {
     string topic = "ssl-keystore-consumer-test-topic";
     crypto:TrustStore trustStore = {
@@ -945,7 +948,7 @@ function sslKeystoreConsumerTest() returns error? {
     check consumer->close();
 }
 
-@test:Config {}
+@test:Config { groups: ["consumer"] }
 function sslCertKeyConsumerTest() returns error? {
     string topic = "ssl-cert-key-consumer-test-topic";
 
@@ -977,7 +980,7 @@ function sslCertKeyConsumerTest() returns error? {
     check consumer->close();
 }
 
-@test:Config {}
+@test:Config { groups: ["consumer"] }
 function sslCertOnlyConsumerTest() returns error? {
     string topic = "ssl-cert-only-consumer-test-topic";
 

--- a/ballerina/tests/consumer_client_tests.bal
+++ b/ballerina/tests/consumer_client_tests.bal
@@ -61,7 +61,7 @@ ProducerConfiguration producerConfiguration = {
 };
 Producer producer = check new (DEFAULT_URL, producerConfiguration);
 
-@test:Config { groups: ["consumer"] }
+@test:Config {}
 function consumerCloseTest() returns error? {
     string topic = "close-test-topic";
     check sendMessage(TEST_MESSAGE.toBytes(), topic);
@@ -82,7 +82,7 @@ function consumerCloseTest() returns error? {
     test:assertEquals(receivedErr.message(), expectedErr);
 }
 
-@test:Config { groups: ["consumer"] }
+@test:Config {}
 function consumerCloseWithDurationTest() returns error? {
     string topic = "close-with-duration-test-topic";
     ConsumerConfiguration consumerConfiguration = {
@@ -102,7 +102,7 @@ function consumerCloseWithDurationTest() returns error? {
     test:assertEquals(receivedErr.message(), expectedErr);
 }
 
-@test:Config { groups: ["consumer"] }
+@test:Config {}
 function consumerCloseWithDefaultTimeoutTest() returns error? {
     string topic = "close-with-default-timeout-test-topic";
     ConsumerConfiguration consumerConfiguration = {
@@ -123,7 +123,7 @@ function consumerCloseWithDefaultTimeoutTest() returns error? {
     test:assertEquals(receivedErr.message(), expectedErr);
 }
 
-@test:Config { groups: ["consumer"] }
+@test:Config {}
 function consumerConfigTest() returns error? {
     string topic = "consumer-config-test-topic";
     ConsumerConfiguration consumerConfiguration = {
@@ -143,7 +143,7 @@ function consumerConfigTest() returns error? {
     check consumer->close();
 }
 
-@test:Config { groups: ["consumer"] }
+@test:Config {}
 function consumerFunctionsTest() returns error? {
     string topic = "consumer-functions-test-topic";
     check sendMessage(TEST_MESSAGE.toBytes(), topic);
@@ -162,7 +162,7 @@ function consumerFunctionsTest() returns error? {
     check consumer->close();
 }
 
-@test:Config { groups: ["consumer"] }
+@test:Config {}
 function consumerSeekTest() returns error? {
     string topic = "consumer-seek-test-topic";
     check sendMessage(TEST_MESSAGE.toBytes(), topic);
@@ -201,7 +201,7 @@ function consumerSeekTest() returns error? {
     check consumer->close();
 }
 
-@test:Config { groups: ["consumer"] }
+@test:Config {}
 function consumerSeekToBeginningTest() returns error? {
     string topic = "consumer-seek-to-beginning-test-topic";
     check sendMessage(TEST_MESSAGE.toBytes(), topic);
@@ -233,7 +233,7 @@ function consumerSeekToBeginningTest() returns error? {
     check consumer->close();
 }
 
-@test:Config { groups: ["consumer"] }
+@test:Config {}
 function consumerSeekToEndTest() returns error? {
     string topic = "consumer-seek-to-end-test-topic";
     check sendMessage(TEST_MESSAGE.toBytes(), topic);
@@ -266,7 +266,7 @@ function consumerSeekToEndTest() returns error? {
     check consumer->close();
 }
 
-@test:Config { groups: ["consumer"] }
+@test:Config {}
 function consumerSeekToNegativeValueTest() returns error? {
     string topic = "consumer-seek-negative-value-test-topic";
     ConsumerConfiguration consumerConfiguration = {
@@ -295,8 +295,7 @@ function consumerSeekToNegativeValueTest() returns error? {
 }
 
 @test:Config {
-    dependsOn: [consumerSeekTest, consumerSeekToBeginningTest, consumerSeekToEndTest],
-    groups: ["consumer"]
+    dependsOn: [consumerSeekTest, consumerSeekToBeginningTest, consumerSeekToEndTest]
 }
 function consumerPositionOffsetsTest() returns error? {
     string topic = "consumer-position-offsets-test-topic";
@@ -335,8 +334,7 @@ function consumerPositionOffsetsTest() returns error? {
 }
 
 @test:Config {
-    dependsOn: [consumerSeekTest, consumerSeekToBeginningTest, consumerSeekToEndTest],
-    groups: ["consumer"]
+    dependsOn: [consumerSeekTest, consumerSeekToBeginningTest, consumerSeekToEndTest]
 }
 function consumerBeginningOffsetsTest() returns error? {
     string topic = "consumer-beginning-offsets-test-topic";
@@ -388,8 +386,7 @@ function consumerBeginningOffsetsTest() returns error? {
 }
 
 @test:Config {
-    dependsOn: [consumerSeekTest, consumerSeekToBeginningTest, consumerSeekToEndTest],
-    groups: ["consumer"]
+    dependsOn: [consumerSeekTest, consumerSeekToBeginningTest, consumerSeekToEndTest]
 }
 function consumerEndOffsetsTest() returns error? {
     string topic = "consumer-end-offsets-test-topic";
@@ -438,7 +435,7 @@ function consumerEndOffsetsTest() returns error? {
     check consumer->close();
 }
 
-@test:Config { groups: ["consumer"] }
+@test:Config {}
 function consumerTopicPartitionsTest() returns error? {
     string topic1 = "consumer-topic-partitions-test-topic-1";
     string topic2 = "consumer-topic-partitions-test-topic-2";
@@ -467,7 +464,7 @@ function consumerTopicPartitionsTest() returns error? {
     check consumer->close();
 }
 
-@test:Config { groups: ["consumer"] }
+@test:Config {}
 function consumerPauseResumePartitionTest() returns error? {
     string topic = "consumer-pause-resume-partition-test-topic";
     ConsumerConfiguration consumerConfiguration = {
@@ -498,7 +495,7 @@ function consumerPauseResumePartitionTest() returns error? {
     check consumer->close();
 }
 
-@test:Config { groups: ["consumer"] }
+@test:Config {}
 function consumerPauseResumePartitionErrorTest() returns error? {
     string topic1 = "consumer-pause-resume-partition-error-test-topic-1";
     string topic2 = "consumer-pause-resume-partition-error-test-topic-2";
@@ -540,7 +537,7 @@ function consumerPauseResumePartitionErrorTest() returns error? {
     check consumer->close();
 }
 
-@test:Config { groups: ["consumer"] }
+@test:Config {}
 function consumerAssignToEmptyTopicTest() returns error? {
     ConsumerConfiguration consumerConfiguration = {
         offsetReset: OFFSET_RESET_EARLIEST,
@@ -562,7 +559,7 @@ function consumerAssignToEmptyTopicTest() returns error? {
     check consumer->close();
 }
 
-@test:Config { groups: ["consumer"] }
+@test:Config {}
 function consumerGetAssignedPartitionsTest() returns error? {
     string topic = "consumer-assigned-partitions-test-topic";
     ConsumerConfiguration consumerConfiguration = {
@@ -584,8 +581,7 @@ function consumerGetAssignedPartitionsTest() returns error? {
 }
 
 @test:Config {
-    dependsOn: [consumerFunctionsTest],
-    groups: ["consumer"]
+    dependsOn: [consumerFunctionsTest]
 }
 function consumerSubscribeUnsubscribeTest() returns error? {
     string topic1 = "consumer-subscribe-unsubscribe-test-topic-1";
@@ -605,7 +601,25 @@ function consumerSubscribeUnsubscribeTest() returns error? {
     check consumer->close();
 }
 
-@test:AfterGroups { value:["consumer", "producer", "listener"] }
+@test:Config {
+    dependsOn: [basicMessageOrderTest, consumerAdditionalPropertiesTest, consumerAssignToEmptyTopicTest,
+        consumerSeekTest, consumerSeekToBeginningTest, consumerSeekToEndTest, consumerBeginningOffsetsTest,
+        consumerCloseTest, consumerCloseWithDefaultTimeoutTest, consumerCloseWithDurationTest, consumerConfigTest,
+        consumerEndOffsetsTest, consumerGetAssignedPartitionsTest, consumerPauseResumePartitionErrorTest,
+        consumerPauseResumePartitionTest, consumerPositionOffsetsTest, consumerSeekToNegativeValueTest,
+        consumerServiceCommitTest, consumerServiceCommitOffsetTest, consumerServiceGracefulStopTest,
+        consumerServiceSubscribeErrorTest, consumerServiceTest, consumerFunctionsTest, consumerSubscribeErrorTest,
+        consumerSubscribeToEmptyTopicTest, consumerSubscribeUnsubscribeTest,
+        consumerSubscribeWithPatternToClosedConsumerTest, consumerTopicPartitionsTest, listenerConfigErrorTest,
+        listenerConfigTest, manualCommitTest, manualCommitWithDefaultTimeoutTest, manualCommitWithDurationTest,
+        moduleLevelListenerTest, nonExistingTopicPartitionOffsetsTest, producerAdditionalPropertiesTest,
+        producerSendStringTest, producerCloseTest, producerFlushTest, producerGetTopicPartitionsErrorTest,
+        producerGetTopicPartitionsTest, producerInitTest, producerKeyTypeMismatchErrorTest,
+        saslConsumerIncorrectCredentialsTest, saslConsumerTest, saslListenerIncorrectCredentialsTest,
+        saslListenerTest, saslProducerIncorrectCredentialsTest, saslProducerTest, sslCertKeyConsumerTest,
+        sslCertKeyProducerTest, sslCertOnlyConsumerTest, sslCertOnlyProducerTest, sslKeystoreConsumerTest,
+        sslListenerTest, sslProducerTest, transactionalProducerTest]
+}
 function consumerSubscribeTest() returns error? {
     Consumer consumer = check new (DEFAULT_URL, {
         groupId: "consumer-subscriber-test-group",
@@ -613,7 +627,7 @@ function consumerSubscribeTest() returns error? {
         metadataMaxAge: 2
     });
     string[] availableTopics = check consumer->getAvailableTopics();
-    test:assertEquals(availableTopics.length(), 53);
+    test:assertEquals(availableTopics.length(), 55);
     string[] subscribedTopics = check consumer->getSubscription();
     test:assertEquals(subscribedTopics.length(), 0);
     check consumer->subscribeWithPattern("consumer.*");
@@ -623,7 +637,7 @@ function consumerSubscribeTest() returns error? {
     check consumer->close();
 }
 
-@test:Config { groups: ["consumer"] }
+@test:Config {}
 function consumerSubscribeWithPatternToClosedConsumerTest() returns error? {
     Consumer consumer = check new (DEFAULT_URL, {
         groupId: "consumer-subscribe-closed-consumer-group",
@@ -640,7 +654,7 @@ function consumerSubscribeWithPatternToClosedConsumerTest() returns error? {
     }
 }
 
-@test:Config { groups: ["consumer"] }
+@test:Config {}
 function consumerSubscribeToEmptyTopicTest() returns error? {
     Consumer consumer = check new (DEFAULT_URL, {
         groupId: "consumer-subscribe-empty-topic-test-group",
@@ -658,7 +672,9 @@ function consumerSubscribeToEmptyTopicTest() returns error? {
     check consumer->close();
 }
 
-@test:AfterGroups { value:["consumer", "producer", "listener"] }
+@test:Config {
+    dependsOn: [consumerSubscribeTest]
+}
 function consumerTopicsAvailableWithTimeoutTest() returns error? {
     Consumer consumer = check new (DEFAULT_URL, {
         groupId: "consumer-topics-available-timeout-test-group-1",
@@ -666,7 +682,7 @@ function consumerTopicsAvailableWithTimeoutTest() returns error? {
         metadataMaxAge: 2
     });
     string[] availableTopics = check consumer->getAvailableTopics(TIMEOUT_DURATION);
-    test:assertEquals(availableTopics.length(), 53);
+    test:assertEquals(availableTopics.length(), 55);
     check consumer->close();
 
     consumer = check new (DEFAULT_URL, {
@@ -676,13 +692,12 @@ function consumerTopicsAvailableWithTimeoutTest() returns error? {
         defaultApiTimeout: DEFAULT_TIMEOUT
     });
     availableTopics = check consumer->getAvailableTopics();
-    test:assertEquals(availableTopics.length(), 53);
+    test:assertEquals(availableTopics.length(), 55);
     check consumer->close();
 }
 
 @test:Config {
-    dependsOn: [consumerFunctionsTest],
-    groups: ["consumer"]
+    dependsOn: [consumerFunctionsTest]
 }
 function consumerSubscribeErrorTest() returns error? {
     string topic = "consumer-subsribe-error-test-topic";
@@ -700,7 +715,7 @@ function consumerSubscribeErrorTest() returns error? {
     check consumer->close();
 }
 
-@test:Config { groups: ["consumer"] }
+@test:Config {}
 function manualCommitTest() returns error? {
     string topic = "manual-commit-test-topic";
     ConsumerConfiguration consumerConfiguration = {
@@ -744,7 +759,7 @@ function manualCommitTest() returns error? {
     check consumer->close();
 }
 
-@test:Config { groups: ["consumer"] }
+@test:Config {}
 function manualCommitWithDurationTest() returns error? {
     string topic = "manual-commit-with-duration-test-topic";
     ConsumerConfiguration consumerConfiguration = {
@@ -774,7 +789,7 @@ function manualCommitWithDurationTest() returns error? {
     check consumer->close();
 }
 
-@test:Config { groups: ["consumer"] }
+@test:Config {}
 function manualCommitWithDefaultTimeoutTest() returns error? {
     string topic = "manual-commit-with-default-timeout-test-topic";
     ConsumerConfiguration consumerConfiguration = {
@@ -805,7 +820,7 @@ function manualCommitWithDefaultTimeoutTest() returns error? {
     check consumer->close();
 }
 
-@test:Config { groups: ["consumer"] }
+@test:Config {}
 function nonExistingTopicPartitionOffsetsTest() returns error? {
     string existingTopic = "existing-test-topic";
     ConsumerConfiguration consumerConfiguration = {
@@ -909,7 +924,7 @@ function consumerAdditionalPropertiesTest() returns error? {
     check consumer->close();
 }
 
-@test:Config { groups: ["consumer"] }
+@test:Config {}
 function sslKeystoreConsumerTest() returns error? {
     string topic = "ssl-keystore-consumer-test-topic";
     crypto:TrustStore trustStore = {
@@ -948,7 +963,7 @@ function sslKeystoreConsumerTest() returns error? {
     check consumer->close();
 }
 
-@test:Config { groups: ["consumer"] }
+@test:Config {}
 function sslCertKeyConsumerTest() returns error? {
     string topic = "ssl-cert-key-consumer-test-topic";
 
@@ -980,7 +995,7 @@ function sslCertKeyConsumerTest() returns error? {
     check consumer->close();
 }
 
-@test:Config { groups: ["consumer"] }
+@test:Config {}
 function sslCertOnlyConsumerTest() returns error? {
     string topic = "ssl-cert-only-consumer-test-topic";
 

--- a/ballerina/tests/consumer_client_tests.bal
+++ b/ballerina/tests/consumer_client_tests.bal
@@ -613,7 +613,7 @@ function consumerSubscribeTest() returns error? {
         metadataMaxAge: 2
     });
     string[] availableTopics = check consumer->getAvailableTopics();
-    test:assertEquals(availableTopics.length(), 52);
+    test:assertEquals(availableTopics.length(), 53);
     string[] subscribedTopics = check consumer->getSubscription();
     test:assertEquals(subscribedTopics.length(), 0);
     check consumer->subscribeWithPattern("consumer.*");
@@ -666,7 +666,7 @@ function consumerTopicsAvailableWithTimeoutTest() returns error? {
         metadataMaxAge: 2
     });
     string[] availableTopics = check consumer->getAvailableTopics(TIMEOUT_DURATION);
-    test:assertEquals(availableTopics.length(), 52);
+    test:assertEquals(availableTopics.length(), 53);
     check consumer->close();
 
     consumer = check new (DEFAULT_URL, {
@@ -676,7 +676,7 @@ function consumerTopicsAvailableWithTimeoutTest() returns error? {
         defaultApiTimeout: DEFAULT_TIMEOUT
     });
     availableTopics = check consumer->getAvailableTopics();
-    test:assertEquals(availableTopics.length(), 52);
+    test:assertEquals(availableTopics.length(), 53);
     check consumer->close();
 }
 

--- a/ballerina/tests/consumer_client_tests.bal
+++ b/ballerina/tests/consumer_client_tests.bal
@@ -611,7 +611,7 @@ function consumerSubscribeTest() returns error? {
         metadataMaxAge: 2
     });
     string[] availableTopics = check consumer->getAvailableTopics();
-    test:assertEquals(availableTopics.length(), 30);
+    test:assertEquals(availableTopics.length(), 31);
     string[] subscribedTopics = check consumer->getSubscription();
     test:assertEquals(subscribedTopics.length(), 0);
     check consumer->subscribeWithPattern("consumer.*");
@@ -664,7 +664,7 @@ function consumerTopicsAvailableWithTimeoutTest() returns error? {
         metadataMaxAge: 2
     });
     string[] availableTopics = check consumer->getAvailableTopics(TIMEOUT_DURATION);
-    test:assertEquals(availableTopics.length(), 32);
+    test:assertEquals(availableTopics.length(), 33);
     check consumer->close();
 
     consumer = check new (DEFAULT_URL, {
@@ -674,7 +674,7 @@ function consumerTopicsAvailableWithTimeoutTest() returns error? {
         defaultApiTimeout: DEFAULT_TIMEOUT
     });
     availableTopics = check consumer->getAvailableTopics();
-    test:assertEquals(availableTopics.length(), 32);
+    test:assertEquals(availableTopics.length(), 33);
     check consumer->close();
 }
 

--- a/ballerina/tests/listener_client_tests.bal
+++ b/ballerina/tests/listener_client_tests.bal
@@ -39,7 +39,7 @@ ConsumerConfiguration moduleLevelConsumerConfiguration = {
 };
 listener Listener moduleLevelListener = check new (DEFAULT_URL, moduleLevelConsumerConfiguration);
 
-@test:Config { groups: ["listener"] }
+@test:Config {}
 function consumerServiceTest() returns error? {
     string topic = "service-test-topic";
     check sendMessage(TEST_MESSAGE.toBytes(), topic);
@@ -58,7 +58,7 @@ function consumerServiceTest() returns error? {
     check consumer.gracefulStop();
 }
 
-@test:Config { groups: ["listener"] }
+@test:Config {}
 function consumerServiceGracefulStopTest() returns error? {
     string topic = "service-graceful-stop-test-topic";
     check sendMessage(TEST_MESSAGE.toBytes(), topic);
@@ -80,7 +80,7 @@ function consumerServiceGracefulStopTest() returns error? {
     test:assertNotEquals(receivedGracefulStopMessage, TEST_MESSAGE_II);
 }
 
-@test:Config { groups: ["listener"] }
+@test:Config {}
 function consumerServiceImmediateStopTest() returns error? {
     string topic = "service-immediate-stop-test-topic";
     check sendMessage(TEST_MESSAGE.toBytes(), topic);
@@ -102,7 +102,7 @@ function consumerServiceImmediateStopTest() returns error? {
     test:assertNotEquals(receivedImmediateStopMessage, TEST_MESSAGE_II);
 }
 
-@test:Config { groups: ["listener"] }
+@test:Config {}
 function consumerServiceSubscribeErrorTest() returns error? {
     string topic = "service-subscribe-error-test-topic";
     check sendMessage(TEST_MESSAGE.toBytes(), topic);
@@ -121,7 +121,7 @@ function consumerServiceSubscribeErrorTest() returns error? {
     }
 }
 
-@test:Config { groups: ["listener"] }
+@test:Config {}
 function listenerConfigTest() returns error? {
     string topic = "listener-config-test-topic";
     ConsumerConfiguration consumerConfiguration = {
@@ -141,7 +141,7 @@ function listenerConfigTest() returns error? {
     check serviceConsumer.gracefulStop();
 }
 
-@test:Config { groups: ["listener"] }
+@test:Config {}
 function listenerConfigErrorTest() returns error? {
     string topic = "listener-config-error-test-topic";
     ConsumerConfiguration consumerConfiguration = {
@@ -179,8 +179,7 @@ function listenerConfigErrorTest() returns error? {
 }
 
 @test:Config {
-    dependsOn: [consumerServiceCommitTest],
-    groups: ["listener"]
+    dependsOn: [consumerServiceCommitTest]
 }
 function consumerServiceCommitOffsetTest() returns error? {
     string topic = "service-commit-offset-test-topic";
@@ -216,7 +215,7 @@ function consumerServiceCommitOffsetTest() returns error? {
     check serviceConsumer.gracefulStop();
 }
 
-@test:Config { groups: ["listener"] }
+@test:Config {}
 function consumerServiceCommitTest() returns error? {
     string topic = "service-commit-test-topic";
     ConsumerConfiguration consumerConfiguration = {
@@ -251,7 +250,7 @@ function consumerServiceCommitTest() returns error? {
     check serviceConsumer.gracefulStop();
 }
 
-@test:Config { groups: ["listener"] }
+@test:Config {}
 function saslListenerTest() returns error? {
     string topic = "sasl-listener-test-topic";
     AuthenticationConfiguration authConfig = {
@@ -278,7 +277,7 @@ function saslListenerTest() returns error? {
     check saslListener.gracefulStop();
 }
 
-@test:Config { groups: ["listener"] }
+@test:Config {}
 function saslListenerIncorrectCredentialsTest() returns error? {
     string topic = "sasl-listener-incorrect-credentials-test-topic";
     AuthenticationConfiguration authConfig = {
@@ -305,7 +304,7 @@ function saslListenerIncorrectCredentialsTest() returns error? {
     check saslListener.gracefulStop();
 }
 
-@test:Config { groups: ["listener"] }
+@test:Config {}
 function sslListenerTest() returns error? {
     string topic = "ssl-listener-test-topic";
 
@@ -348,7 +347,7 @@ function sslListenerTest() returns error? {
     check saslListener.gracefulStop();
 }
 
-@test:Config { groups: ["listener"] }
+@test:Config {}
 function basicMessageOrderTest() returns error? {
     string topic = "message-order-topic";
     int i = 0;
@@ -380,7 +379,7 @@ function basicMessageOrderTest() returns error? {
     check consumer.gracefulStop();
 }
 
-@test:Config { groups: ["listener"] }
+@test:Config {}
 function moduleLevelListenerTest() returns error? {
     check sendMessage(TEST_MESSAGE.toBytes(), moduleLevelListenerTopic);
     check moduleLevelListener.attach(moduleLevelListenerService);

--- a/ballerina/tests/listener_client_tests.bal
+++ b/ballerina/tests/listener_client_tests.bal
@@ -39,7 +39,7 @@ ConsumerConfiguration moduleLevelConsumerConfiguration = {
 };
 listener Listener moduleLevelListener = check new (DEFAULT_URL, moduleLevelConsumerConfiguration);
 
-@test:Config {}
+@test:Config { groups: ["listener"] }
 function consumerServiceTest() returns error? {
     string topic = "service-test-topic";
     check sendMessage(TEST_MESSAGE.toBytes(), topic);
@@ -53,11 +53,12 @@ function consumerServiceTest() returns error? {
     check consumer.attach(consumerService);
     check consumer.'start();
 
-    runtime:sleep(7);
+    runtime:sleep(3);
     test:assertEquals(receivedMessage, TEST_MESSAGE);
+    check consumer.gracefulStop();
 }
 
-@test:Config {}
+@test:Config { groups: ["listener"] }
 function consumerServiceGracefulStopTest() returns error? {
     string topic = "service-graceful-stop-test-topic";
     check sendMessage(TEST_MESSAGE.toBytes(), topic);
@@ -70,16 +71,16 @@ function consumerServiceGracefulStopTest() returns error? {
     Listener consumer = check new (DEFAULT_URL, consumerConfiguration);
     check consumer.attach(consumerGracefulStopService);
     check consumer.'start();
-    runtime:sleep(7);
+    runtime:sleep(3);
     test:assertEquals(receivedGracefulStopMessage, TEST_MESSAGE);
 
     check consumer.gracefulStop();
     check sendMessage(TEST_MESSAGE_II.toBytes(), topic);
-    runtime:sleep(7);
+    runtime:sleep(3);
     test:assertNotEquals(receivedGracefulStopMessage, TEST_MESSAGE_II);
 }
 
-@test:Config {}
+@test:Config { groups: ["listener"] }
 function consumerServiceImmediateStopTest() returns error? {
     string topic = "service-immediate-stop-test-topic";
     check sendMessage(TEST_MESSAGE.toBytes(), topic);
@@ -92,16 +93,16 @@ function consumerServiceImmediateStopTest() returns error? {
     Listener consumer = check new (DEFAULT_URL, consumerConfiguration);
     check consumer.attach(consumerImmediateStopService);
     check consumer.'start();
-    runtime:sleep(7);
+    runtime:sleep(3);
     test:assertEquals(receivedImmediateStopMessage, TEST_MESSAGE);
 
     check consumer.immediateStop();
     check sendMessage(TEST_MESSAGE_II.toBytes(), topic);
-    runtime:sleep(7);
+    runtime:sleep(3);
     test:assertNotEquals(receivedImmediateStopMessage, TEST_MESSAGE_II);
 }
 
-@test:Config {}
+@test:Config { groups: ["listener"] }
 function consumerServiceSubscribeErrorTest() returns error? {
     string topic = "service-subscribe-error-test-topic";
     check sendMessage(TEST_MESSAGE.toBytes(), topic);
@@ -120,7 +121,7 @@ function consumerServiceSubscribeErrorTest() returns error? {
     }
 }
 
-@test:Config {}
+@test:Config { groups: ["listener"] }
 function listenerConfigTest() returns error? {
     string topic = "listener-config-test-topic";
     ConsumerConfiguration consumerConfiguration = {
@@ -135,11 +136,12 @@ function listenerConfigTest() returns error? {
     check serviceConsumer.attach(consumerConfigService);
     check serviceConsumer.'start();
     check sendMessage(TEST_MESSAGE.toBytes(), topic);
-    runtime:sleep(7);
+    runtime:sleep(3);
     test:assertEquals(receivedConfigMessage, TEST_MESSAGE);
+    check serviceConsumer.gracefulStop();
 }
 
-@test:Config {}
+@test:Config { groups: ["listener"] }
 function listenerConfigErrorTest() returns error? {
     string topic = "listener-config-error-test-topic";
     ConsumerConfiguration consumerConfiguration = {
@@ -177,7 +179,8 @@ function listenerConfigErrorTest() returns error? {
 }
 
 @test:Config {
-    dependsOn: [consumerServiceCommitTest]
+    dependsOn: [consumerServiceCommitTest],
+    groups: ["listener"]
 }
 function consumerServiceCommitOffsetTest() returns error? {
     string topic = "service-commit-offset-test-topic";
@@ -210,9 +213,10 @@ function consumerServiceCommitOffsetTest() returns error? {
 
     test:assertEquals(offsetValue, messageCount);
     check consumer->close();
+    check serviceConsumer.gracefulStop();
 }
 
-@test:Config {}
+@test:Config { groups: ["listener"] }
 function consumerServiceCommitTest() returns error? {
     string topic = "service-commit-test-topic";
     ConsumerConfiguration consumerConfiguration = {
@@ -244,9 +248,10 @@ function consumerServiceCommitTest() returns error? {
 
     test:assertEquals(offsetValue, messageCount);
     check consumer->close();
+    check serviceConsumer.gracefulStop();
 }
 
-@test:Config {}
+@test:Config { groups: ["listener"] }
 function saslListenerTest() returns error? {
     string topic = "sasl-listener-test-topic";
     AuthenticationConfiguration authConfig = {
@@ -268,11 +273,12 @@ function saslListenerTest() returns error? {
     check saslListener.attach(saslConsumerService);
     check saslListener.'start();
     check sendMessage(TEST_MESSAGE.toBytes(), topic);
-    runtime:sleep(7);
+    runtime:sleep(3);
     test:assertEquals(saslMsg, TEST_MESSAGE);
+    check saslListener.gracefulStop();
 }
 
-@test:Config {}
+@test:Config { groups: ["listener"] }
 function saslListenerIncorrectCredentialsTest() returns error? {
     string topic = "sasl-listener-incorrect-credentials-test-topic";
     AuthenticationConfiguration authConfig = {
@@ -294,11 +300,12 @@ function saslListenerIncorrectCredentialsTest() returns error? {
     check saslListener.attach(saslConsumerIncorrectCredentialsService);
     check saslListener.'start();
     check sendMessage(TEST_MESSAGE.toBytes(), topic);
-    runtime:sleep(7);
+    runtime:sleep(3);
     test:assertEquals(saslMsg, EMPTY_MEESAGE);
+    check saslListener.gracefulStop();
 }
 
-@test:Config {}
+@test:Config { groups: ["listener"] }
 function sslListenerTest() returns error? {
     string topic = "ssl-listener-test-topic";
 
@@ -336,11 +343,12 @@ function sslListenerTest() returns error? {
     check saslListener.attach(sslConsumerService);
     check saslListener.'start();
     check sendMessage(TEST_MESSAGE.toBytes(), topic);
-    runtime:sleep(7);
+    runtime:sleep(3);
     test:assertEquals(sslMsg, TEST_MESSAGE);
+    check saslListener.gracefulStop();
 }
 
-@test:Config {}
+@test:Config { groups: ["listener"] }
 function basicMessageOrderTest() returns error? {
     string topic = "message-order-topic";
     int i = 0;
@@ -359,25 +367,25 @@ function basicMessageOrderTest() returns error? {
     check consumer.attach(messageOrderService);
     check consumer.'start();
 
-    runtime:sleep(7);
+    runtime:sleep(3);
 
     while (i < 10) {
         string message = i.toString();
         check sendMessage(message.toBytes(), topic);
         i += 1;
     }
-    runtime:sleep(7);
+    runtime:sleep(3);
     string expected = "0123456789";
     test:assertEquals(messagesReceivedInOrder, expected);
+    check consumer.gracefulStop();
 }
 
-@test:Config {}
+@test:Config { groups: ["listener"] }
 function moduleLevelListenerTest() returns error? {
     check sendMessage(TEST_MESSAGE.toBytes(), moduleLevelListenerTopic);
     check moduleLevelListener.attach(moduleLevelListenerService);
     check moduleLevelListener.'start();
-
-    runtime:sleep(7);
+    runtime:sleep(3);
 
     test:assertEquals(moduleLevelListenerMessage, TEST_MESSAGE);
     check moduleLevelListener.gracefulStop();

--- a/ballerina/tests/producer_client_tests.bal
+++ b/ballerina/tests/producer_client_tests.bal
@@ -23,7 +23,7 @@ string MESSAGE_KEY = "TEST-KEY";
 const string INVALID_URL = "127.0.0.1.1:9099";
 const string INCORRECT_KAFKA_URL = "localhost:9099";
 
-@test:Config{}
+@test:Config { groups: ["producer"] }
 function producerInitTest() returns error? {
     ProducerConfiguration producerConfiguration1 = {
         clientId: "test-producer-02",
@@ -73,7 +73,7 @@ function producerInitTest() returns error? {
     }
 }
 
-@test:Config {}
+@test:Config { groups: ["producer"] }
 function producerSendStringTest() returns error? {
     string topic = "send-string-test-topic";
     Producer stringProducer = check new (DEFAULT_URL, producerConfiguration);
@@ -98,7 +98,7 @@ function producerSendStringTest() returns error? {
     check consumer->close();
 }
 
-@test:Config {}
+@test:Config { groups: ["producer"] }
 function producerKeyTypeMismatchErrorTest() returns error? {
     string topic = "key-type-mismatch-error-test-topic";
     Producer producer = check new (DEFAULT_URL, producerConfiguration);
@@ -114,7 +114,8 @@ function producerKeyTypeMismatchErrorTest() returns error? {
 }
 
 @test:Config {
-    dependsOn: [producerSendStringTest]
+    dependsOn: [producerSendStringTest],
+    groups: ["producer"]
 }
 function producerCloseTest() returns error? {
     string topic = "producer-close-test-topic";
@@ -131,7 +132,7 @@ function producerCloseTest() returns error? {
     test:assertEquals(receivedErr.message(), expectedErr);
 }
 
-@test:Config {}
+@test:Config { groups: ["producer"] }
 function producerFlushTest() returns error? {
     string topic = "producer-flush-test-topic";
     Producer producer = check new (DEFAULT_URL, producerConfiguration);
@@ -151,7 +152,7 @@ function producerFlushTest() returns error? {
     check consumer->close();
 }
 
-@test:Config {}
+@test:Config { groups: ["producer"] }
 function producerGetTopicPartitionsTest() returns error? {
     string topic = "get-topic-partitions-test-topic";
     Producer producer = check new (DEFAULT_URL, producerConfiguration);
@@ -160,7 +161,7 @@ function producerGetTopicPartitionsTest() returns error? {
     check producer->close();
 }
 
-@test:Config {}
+@test:Config { groups: ["producer"] }
 function producerGetTopicPartitionsErrorTest() returns error? {
     string topic = "get-topic-partitions-error-test-topic";
     Producer producer = check new (INCORRECT_KAFKA_URL, producerConfiguration);
@@ -175,7 +176,7 @@ function producerGetTopicPartitionsErrorTest() returns error? {
     check producer->close();
 }
 
-@test:Config {}
+@test:Config { groups: ["producer"] }
 function transactionalProducerTest() returns error? {
     string topic = "transactional-producer-test-topic";
     ProducerConfiguration producerConfigs = {
@@ -213,7 +214,7 @@ function transactionalProducerTest() returns error? {
     check consumer->close();
 }
 
-@test:Config{}
+@test:Config { groups: ["producer"] }
 function saslProducerTest() returns error? {
     string topic = "sasl-producer-test-topic";
     AuthenticationConfiguration authConfig = {
@@ -250,7 +251,7 @@ function saslProducerTest() returns error? {
     check consumer->close();
 }
 
-@test:Config{}
+@test:Config { groups: ["producer"] }
 function saslProducerIncorrectCredentialsTest() returns error? {
     string topic = "sasl-producer-incorrect-credentials-test-topic";
     AuthenticationConfiguration authConfig = {
@@ -281,7 +282,7 @@ function saslProducerIncorrectCredentialsTest() returns error? {
     check kafkaProducer->close();
 }
 
-@test:Config {}
+@test:Config { groups: ["producer"] }
 function producerAdditionalPropertiesTest() returns error? {
     string topic = "producer-additional-properties-test-topic";
     map<string> propertyMap = {
@@ -319,7 +320,7 @@ function producerAdditionalPropertiesTest() returns error? {
     check consumer->close();
 }
 
-@test:Config {}
+@test:Config { groups: ["producer"] }
 function sslProducerTest() returns error? {
     string topic = "ssl-producer-test-topic";
     crypto:TrustStore trustStore = {
@@ -368,7 +369,7 @@ function sslProducerTest() returns error? {
     check consumer->close();
 }
 
-@test:Config {}
+@test:Config { groups: ["producer"] }
 function sslCertKeyProducerTest() returns error? {
     string topic = "ssl-cert-key-producer-test-topic";
 
@@ -410,7 +411,7 @@ function sslCertKeyProducerTest() returns error? {
     check consumer->close();
 }
 
-@test:Config {}
+@test:Config { groups: ["producer"] }
 function sslCertOnlyProducerTest() returns error? {
     string topic = "ssl-cert-only-producer-test-topic";
 

--- a/ballerina/tests/producer_client_tests.bal
+++ b/ballerina/tests/producer_client_tests.bal
@@ -23,7 +23,7 @@ string MESSAGE_KEY = "TEST-KEY";
 const string INVALID_URL = "127.0.0.1.1:9099";
 const string INCORRECT_KAFKA_URL = "localhost:9099";
 
-@test:Config { groups: ["producer"] }
+@test:Config {}
 function producerInitTest() returns error? {
     ProducerConfiguration producerConfiguration1 = {
         clientId: "test-producer-02",
@@ -73,7 +73,7 @@ function producerInitTest() returns error? {
     }
 }
 
-@test:Config { groups: ["producer"] }
+@test:Config {}
 function producerSendStringTest() returns error? {
     string topic = "send-string-test-topic";
     Producer stringProducer = check new (DEFAULT_URL, producerConfiguration);
@@ -98,7 +98,7 @@ function producerSendStringTest() returns error? {
     check consumer->close();
 }
 
-@test:Config { groups: ["producer"] }
+@test:Config {}
 function producerKeyTypeMismatchErrorTest() returns error? {
     string topic = "key-type-mismatch-error-test-topic";
     Producer producer = check new (DEFAULT_URL, producerConfiguration);
@@ -114,8 +114,7 @@ function producerKeyTypeMismatchErrorTest() returns error? {
 }
 
 @test:Config {
-    dependsOn: [producerSendStringTest],
-    groups: ["producer"]
+    dependsOn: [producerSendStringTest]
 }
 function producerCloseTest() returns error? {
     string topic = "producer-close-test-topic";
@@ -132,7 +131,7 @@ function producerCloseTest() returns error? {
     test:assertEquals(receivedErr.message(), expectedErr);
 }
 
-@test:Config { groups: ["producer"] }
+@test:Config {}
 function producerFlushTest() returns error? {
     string topic = "producer-flush-test-topic";
     Producer producer = check new (DEFAULT_URL, producerConfiguration);
@@ -152,7 +151,7 @@ function producerFlushTest() returns error? {
     check consumer->close();
 }
 
-@test:Config { groups: ["producer"] }
+@test:Config {}
 function producerGetTopicPartitionsTest() returns error? {
     string topic = "get-topic-partitions-test-topic";
     Producer producer = check new (DEFAULT_URL, producerConfiguration);
@@ -161,7 +160,7 @@ function producerGetTopicPartitionsTest() returns error? {
     check producer->close();
 }
 
-@test:Config { groups: ["producer"] }
+@test:Config {}
 function producerGetTopicPartitionsErrorTest() returns error? {
     string topic = "get-topic-partitions-error-test-topic";
     Producer producer = check new (INCORRECT_KAFKA_URL, producerConfiguration);
@@ -176,7 +175,7 @@ function producerGetTopicPartitionsErrorTest() returns error? {
     check producer->close();
 }
 
-@test:Config { groups: ["producer"] }
+@test:Config {}
 function transactionalProducerTest() returns error? {
     string topic = "transactional-producer-test-topic";
     ProducerConfiguration producerConfigs = {
@@ -214,7 +213,7 @@ function transactionalProducerTest() returns error? {
     check consumer->close();
 }
 
-@test:Config { groups: ["producer"] }
+@test:Config {}
 function saslProducerTest() returns error? {
     string topic = "sasl-producer-test-topic";
     AuthenticationConfiguration authConfig = {
@@ -251,7 +250,7 @@ function saslProducerTest() returns error? {
     check consumer->close();
 }
 
-@test:Config { groups: ["producer"] }
+@test:Config {}
 function saslProducerIncorrectCredentialsTest() returns error? {
     string topic = "sasl-producer-incorrect-credentials-test-topic";
     AuthenticationConfiguration authConfig = {
@@ -282,7 +281,7 @@ function saslProducerIncorrectCredentialsTest() returns error? {
     check kafkaProducer->close();
 }
 
-@test:Config { groups: ["producer"] }
+@test:Config {}
 function producerAdditionalPropertiesTest() returns error? {
     string topic = "producer-additional-properties-test-topic";
     map<string> propertyMap = {
@@ -320,7 +319,7 @@ function producerAdditionalPropertiesTest() returns error? {
     check consumer->close();
 }
 
-@test:Config { groups: ["producer"] }
+@test:Config {}
 function sslProducerTest() returns error? {
     string topic = "ssl-producer-test-topic";
     crypto:TrustStore trustStore = {
@@ -369,7 +368,7 @@ function sslProducerTest() returns error? {
     check consumer->close();
 }
 
-@test:Config { groups: ["producer"] }
+@test:Config {}
 function sslCertKeyProducerTest() returns error? {
     string topic = "ssl-cert-key-producer-test-topic";
 
@@ -411,7 +410,7 @@ function sslCertKeyProducerTest() returns error? {
     check consumer->close();
 }
 
-@test:Config { groups: ["producer"] }
+@test:Config {}
 function sslCertOnlyProducerTest() returns error? {
     string topic = "ssl-cert-only-producer-test-topic";
 

--- a/native/src/main/java/io/ballerina/stdlib/kafka/impl/KafkaServerConnectorImpl.java
+++ b/native/src/main/java/io/ballerina/stdlib/kafka/impl/KafkaServerConnectorImpl.java
@@ -41,6 +41,7 @@ public class KafkaServerConnectorImpl implements KafkaServerConnector {
     private int numOfConcurrentConsumers = 1;
     private List<KafkaRecordConsumer> messageConsumers;
     private KafkaConsumer kafkaConsumer;
+    private boolean started = false;
 
     public KafkaServerConnectorImpl(String serviceId, Properties configParams, KafkaListener kafkaListener,
                                     KafkaConsumer kafkaConsumer) throws KafkaConnectorException {
@@ -71,6 +72,7 @@ public class KafkaServerConnectorImpl implements KafkaServerConnector {
                 this.messageConsumers.add(consumer);
                 consumer.consume();
             }
+            this.started = true;
         } catch (KafkaException e) {
             throw new KafkaConnectorException(
                     "Error creating Kafka consumer to connect with remote broker and subscribe to provided topics", e);
@@ -95,6 +97,7 @@ public class KafkaServerConnectorImpl implements KafkaServerConnector {
             }
         }
         this.messageConsumers = null;
+        this.started = false;
         if (ex != null) {
             throw ex;
         }
@@ -119,9 +122,14 @@ public class KafkaServerConnectorImpl implements KafkaServerConnector {
             }
         }
         this.messageConsumers = null;
+        this.started = false;
         if (ex != null) {
             throw ex;
         }
         return true;
+    }
+
+    public boolean isStarted() {
+        return started;
     }
 }

--- a/native/src/main/java/io/ballerina/stdlib/kafka/service/Start.java
+++ b/native/src/main/java/io/ballerina/stdlib/kafka/service/Start.java
@@ -38,6 +38,9 @@ public class Start {
 
     public static Object start(BObject listener) {
         KafkaServerConnectorImpl serverConnector = (KafkaServerConnectorImpl) listener.getNativeData(SERVER_CONNECTOR);
+        if (serverConnector == null || serverConnector.isStarted()) {
+            return null;
+        }
         try {
             serverConnector.start();
             console.println(SERVICE_STARTED + getTopicNamesString((List<String>) listener.getNativeData("topics")));


### PR DESCRIPTION
## Purpose
When the `kafka:Listener` is initialized outside a main function as depicted in the issue, the service `start` function gets called twice, once by the runtime and the second time by the user. This PR will introduce a check to make sure to stop starting the consumer for a second time which will result in a `concurrrentModificationException`.
## Examples
N/A
## Checklist
- [x] Linked to an issue
- [ ] Updated the changelog
- [x] Added tests

Fixes https://github.com/ballerina-platform/ballerina-standard-library/issues/1780