### PR TITLE
Fix commit and rollback not getting invoked inside transaction block

### DIFF
--- a/ballerina/Dependencies.toml
+++ b/ballerina/Dependencies.toml
@@ -181,9 +181,6 @@ scope = "testOnly"
 dependencies = [
 	{org = "ballerina", name = "jballerina.java"}
 ]
-modules = [
-	{org = "ballerina", packageName = "lang.string", moduleName = "lang.string"}
-]
 
 [[package]]
 org = "ballerina"
@@ -359,7 +356,6 @@ dependencies = [
 	{org = "ballerina", name = "crypto"},
 	{org = "ballerina", name = "io"},
 	{org = "ballerina", name = "jballerina.java"},
-	{org = "ballerina", name = "lang.string"},
 	{org = "ballerina", name = "test"},
 	{org = "ballerina", name = "uuid"},
 	{org = "ballerinai", name = "observe"},

--- a/ballerina/Dependencies.toml
+++ b/ballerina/Dependencies.toml
@@ -172,6 +172,9 @@ scope = "testOnly"
 dependencies = [
 	{org = "ballerina", name = "jballerina.java"}
 ]
+modules = [
+	{org = "ballerina", packageName = "lang.runtime", moduleName = "lang.runtime"}
+]
 
 [[package]]
 org = "ballerina"
@@ -180,6 +183,9 @@ version = "0.0.0"
 scope = "testOnly"
 dependencies = [
 	{org = "ballerina", name = "jballerina.java"}
+]
+modules = [
+	{org = "ballerina", packageName = "lang.string", moduleName = "lang.string"}
 ]
 
 [[package]]
@@ -210,6 +216,9 @@ dependencies = [
 	{org = "ballerina", name = "jballerina.java"},
 	{org = "ballerina", name = "lang.value"},
 	{org = "ballerina", name = "observe"}
+]
+modules = [
+	{org = "ballerina", packageName = "log", moduleName = "log"}
 ]
 
 [[package]]
@@ -356,6 +365,9 @@ dependencies = [
 	{org = "ballerina", name = "crypto"},
 	{org = "ballerina", name = "io"},
 	{org = "ballerina", name = "jballerina.java"},
+	{org = "ballerina", name = "lang.runtime"},
+	{org = "ballerina", name = "lang.string"},
+	{org = "ballerina", name = "log"},
 	{org = "ballerina", name = "test"},
 	{org = "ballerina", name = "uuid"},
 	{org = "ballerinai", name = "observe"},

--- a/ballerina/tests/producer_client_tests.bal
+++ b/ballerina/tests/producer_client_tests.bal
@@ -217,6 +217,59 @@ function transactionalProducerTest() returns error? {
     return;
 }
 
+@test:Config {}
+function transactionalProducerWithAbortTest() returns error? {
+    string topic = "rollback-producer-test-topic";
+    ProducerConfiguration producerConfigs = {
+        clientId: "test-producer-05",
+        acks: "all",
+        retryCount: 3,
+        enableIdempotence: true,
+        transactionalId: "producer-abort-transactional-id"
+    };
+    Producer producer = check new (DEFAULT_URL, producerConfigs);
+    do {
+        transaction {
+            check producer->send({ topic: topic, value: TEST_MESSAGE.toBytes(), partition: 0});
+            check producer->send({ topic: topic, value: TEST_MESSAGE.toBytes(), partition: 0});
+            check producer->send({ topic: topic, value: TEST_MESSAGE.toBytes(), partition: 0});
+            check failTransaction();
+            check commit;
+        }
+    } on fail var e {
+        io:println(e.toString());
+    }
+    check producer->close();
+
+    ConsumerConfiguration consumerConfiguration = {
+        topics: [topic],
+        offsetReset: OFFSET_RESET_EARLIEST,
+        groupId: "committed-transactional-test-group",
+        clientId: "test-consumer-49",
+        isolationLevel: ISOLATION_COMMITTED
+    };
+    Consumer consumer = check new (DEFAULT_URL, consumerConfiguration);
+    ConsumerRecord[] consumerRecords = check consumer->poll(5);
+    test:assertEquals(consumerRecords.length(), 0, "Expected: 0. Received: " + consumerRecords.length().toString());
+    check consumer->close();
+
+    consumerConfiguration = {
+        topics: [topic],
+        offsetReset: OFFSET_RESET_EARLIEST,
+        groupId: "uncommitted-transactional-test-group",
+        clientId: "test-consumer-50",
+        isolationLevel: ISOLATION_UNCOMMITTED
+    };
+    consumer = check new (DEFAULT_URL, consumerConfiguration);
+    consumerRecords = check consumer->poll(5);
+    test:assertEquals(consumerRecords.length(), 3, "Expected: 3. Received: " + consumerRecords.length().toString());
+    check consumer->close();
+}
+
+isolated function failTransaction() returns error {
+    return error("Fail!");
+}
+
 @test:Config{}
 function saslProducerTest() returns error? {
     string topic = "sasl-producer-test-topic";

--- a/native/src/main/java/io/ballerina/stdlib/kafka/utils/TransactionUtils.java
+++ b/native/src/main/java/io/ballerina/stdlib/kafka/utils/TransactionUtils.java
@@ -61,5 +61,8 @@ public class TransactionUtils {
                                                        KafkaTransactionContext transactionContext, String connectorId) {
         TransactionLocalContext transactionLocalContext = trxResourceManager.getCurrentTransactionContext();
         transactionLocalContext.registerTransactionContext(connectorId, transactionContext);
+        String globalTxId = transactionLocalContext.getGlobalTransactionId();
+        String currentTxBlockId = transactionLocalContext.getCurrentTransactionBlockId();
+        TransactionResourceManager.getInstance().register(globalTxId, currentTxBlockId, transactionContext);
     }
 }


### PR DESCRIPTION
## Purpose
$subject
Kafka supports transaction rollback via the `kafkaProducer.abortTransaction();` API. With this, a consumer with `isolationLevel: ISOLATION_COMMITTED` will not receive the aborted messages in the transaction.
## Examples

## Checklist
- [x] Linked to an issue
- [ ] Updated the changelog
- [x] Added tests
