### PR TITLE
Skip examples from daily docker build

### DIFF
--- a/.github/workflows/daily-build.yml
+++ b/.github/workflows/daily-build.yml
@@ -22,7 +22,7 @@ jobs:
         if: github.event.action == 'check_connector_for_breaking_changes'
         run: |
           echo "BUILD_USING_DOCKER=-PbuildUsingDocker=nightly" >> $GITHUB_ENV
-          echo "GRADLE_SKIP_TASKS=-x :kafka-compiler-plugin-tests:test"  >> $GITHUB_ENV
+          echo "GRADLE_SKIP_TASKS=-x :kafka-compiler-plugin-tests:test -x :kafka-examples:build"  >> $GITHUB_ENV
 
       # Build the project with Gradle
       - name: Build with Gradle


### PR DESCRIPTION
## Purpose
$subject
When the build is done using docker, `target` is not created and therefore cannot build and test the examples just as `compiler-plugin-tests`
## Examples

## Checklist
- [ ] ~Linked to an issue~
- [ ] ~Updated the changelog~
- [ ] ~Added tests~
- [ ] ~Updated the spec~
