### PR TITLE
Fix failing tests after testerina migration

### DIFF
--- a/ballerina/Dependencies.toml
+++ b/ballerina/Dependencies.toml
@@ -9,7 +9,7 @@ dependencies-toml-version = "2"
 [[package]]
 org = "ballerina"
 name = "auth"
-version = "2.4.0"
+version = "2.4.1"
 scope = "testOnly"
 dependencies = [
 	{org = "ballerina", name = "crypto"},
@@ -23,9 +23,10 @@ dependencies = [
 [[package]]
 org = "ballerina"
 name = "cache"
-version = "3.2.2"
+version = "3.3.0"
 scope = "testOnly"
 dependencies = [
+	{org = "ballerina", name = "constraint"},
 	{org = "ballerina", name = "jballerina.java"},
 	{org = "ballerina", name = "task"},
 	{org = "ballerina", name = "time"}
@@ -46,7 +47,7 @@ modules = [
 [[package]]
 org = "ballerina"
 name = "crypto"
-version = "2.2.2"
+version = "2.2.3"
 dependencies = [
 	{org = "ballerina", name = "jballerina.java"},
 	{org = "ballerina", name = "time"}
@@ -58,7 +59,7 @@ modules = [
 [[package]]
 org = "ballerina"
 name = "file"
-version = "1.4.0"
+version = "1.4.1"
 scope = "testOnly"
 dependencies = [
 	{org = "ballerina", name = "io"},
@@ -72,7 +73,7 @@ dependencies = [
 [[package]]
 org = "ballerina"
 name = "http"
-version = "2.4.0"
+version = "2.4.1"
 scope = "testOnly"
 dependencies = [
 	{org = "ballerina", name = "auth"},
@@ -122,7 +123,7 @@ modules = [
 [[package]]
 org = "ballerina"
 name = "jwt"
-version = "2.4.0"
+version = "2.4.1"
 scope = "testOnly"
 dependencies = [
 	{org = "ballerina", name = "cache"},
@@ -251,7 +252,7 @@ dependencies = [
 [[package]]
 org = "ballerina"
 name = "oauth2"
-version = "2.4.0"
+version = "2.4.1"
 scope = "testOnly"
 dependencies = [
 	{org = "ballerina", name = "cache"},
@@ -272,7 +273,7 @@ dependencies = [
 [[package]]
 org = "ballerina"
 name = "os"
-version = "1.4.0"
+version = "1.4.1"
 scope = "testOnly"
 dependencies = [
 	{org = "ballerina", name = "io"},
@@ -291,7 +292,7 @@ dependencies = [
 [[package]]
 org = "ballerina"
 name = "task"
-version = "2.2.2"
+version = "2.2.3"
 scope = "testOnly"
 dependencies = [
 	{org = "ballerina", name = "jballerina.java"},
@@ -330,7 +331,7 @@ dependencies = [
 [[package]]
 org = "ballerina"
 name = "uuid"
-version = "1.3.0"
+version = "1.3.1"
 dependencies = [
 	{org = "ballerina", name = "crypto"},
 	{org = "ballerina", name = "jballerina.java"},

--- a/ballerina/Dependencies.toml
+++ b/ballerina/Dependencies.toml
@@ -9,7 +9,7 @@ dependencies-toml-version = "2"
 [[package]]
 org = "ballerina"
 name = "auth"
-version = "2.4.1"
+version = "2.4.0"
 scope = "testOnly"
 dependencies = [
 	{org = "ballerina", name = "crypto"},
@@ -23,10 +23,9 @@ dependencies = [
 [[package]]
 org = "ballerina"
 name = "cache"
-version = "3.3.0"
+version = "3.2.2"
 scope = "testOnly"
 dependencies = [
-	{org = "ballerina", name = "constraint"},
 	{org = "ballerina", name = "jballerina.java"},
 	{org = "ballerina", name = "task"},
 	{org = "ballerina", name = "time"}
@@ -47,7 +46,7 @@ modules = [
 [[package]]
 org = "ballerina"
 name = "crypto"
-version = "2.2.3"
+version = "2.2.2"
 dependencies = [
 	{org = "ballerina", name = "jballerina.java"},
 	{org = "ballerina", name = "time"}
@@ -59,7 +58,7 @@ modules = [
 [[package]]
 org = "ballerina"
 name = "file"
-version = "1.4.1"
+version = "1.4.0"
 scope = "testOnly"
 dependencies = [
 	{org = "ballerina", name = "io"},
@@ -73,7 +72,7 @@ dependencies = [
 [[package]]
 org = "ballerina"
 name = "http"
-version = "2.4.1"
+version = "2.4.0"
 scope = "testOnly"
 dependencies = [
 	{org = "ballerina", name = "auth"},
@@ -123,7 +122,7 @@ modules = [
 [[package]]
 org = "ballerina"
 name = "jwt"
-version = "2.4.1"
+version = "2.4.0"
 scope = "testOnly"
 dependencies = [
 	{org = "ballerina", name = "cache"},
@@ -252,7 +251,7 @@ dependencies = [
 [[package]]
 org = "ballerina"
 name = "oauth2"
-version = "2.4.1"
+version = "2.4.0"
 scope = "testOnly"
 dependencies = [
 	{org = "ballerina", name = "cache"},
@@ -273,7 +272,7 @@ dependencies = [
 [[package]]
 org = "ballerina"
 name = "os"
-version = "1.4.1"
+version = "1.4.0"
 scope = "testOnly"
 dependencies = [
 	{org = "ballerina", name = "io"},
@@ -292,7 +291,7 @@ dependencies = [
 [[package]]
 org = "ballerina"
 name = "task"
-version = "2.2.3"
+version = "2.2.2"
 scope = "testOnly"
 dependencies = [
 	{org = "ballerina", name = "jballerina.java"},
@@ -331,7 +330,7 @@ dependencies = [
 [[package]]
 org = "ballerina"
 name = "uuid"
-version = "1.3.1"
+version = "1.3.0"
 dependencies = [
 	{org = "ballerina", name = "crypto"},
 	{org = "ballerina", name = "jballerina.java"},

--- a/ballerina/Dependencies.toml
+++ b/ballerina/Dependencies.toml
@@ -181,6 +181,14 @@ scope = "testOnly"
 
 [[package]]
 org = "ballerina"
+name = "lang.regexp"
+version = "0.0.0"
+dependencies = [
+	{org = "ballerina", name = "jballerina.java"}
+]
+
+[[package]]
+org = "ballerina"
 name = "lang.runtime"
 version = "0.0.0"
 scope = "testOnly"
@@ -196,7 +204,8 @@ org = "ballerina"
 name = "lang.string"
 version = "0.0.0"
 dependencies = [
-	{org = "ballerina", name = "jballerina.java"}
+	{org = "ballerina", name = "jballerina.java"},
+	{org = "ballerina", name = "lang.regexp"}
 ]
 modules = [
 	{org = "ballerina", packageName = "lang.string", moduleName = "lang.string"}

--- a/ballerina/tests/consumer_constraint_tests.bal
+++ b/ballerina/tests/consumer_constraint_tests.bal
@@ -84,6 +84,7 @@ int receivedSeekedValidRecordCount = 0;
 @test:Config {enable: true}
 function stringMinLengthConstraintConsumerRecordTest() returns error? {
     string topic = "string-min-length-constraint-consumer-record-test-topic";
+    kafkaTopics.push(topic);
     check sendMessage("Short msg", topic);
 
     ConsumerConfiguration consumerConfigs = {
@@ -106,6 +107,7 @@ function stringMinLengthConstraintConsumerRecordTest() returns error? {
 @test:Config {enable: true}
 function stringMaxLengthConstraintConsumerRecordTest() returns error? {
     string topic = "string-max-length-constraint-consumer-record-test-topic";
+    kafkaTopics.push(topic);
     check sendMessage("This is a long message with a long key", topic, "key-00000000000002");
 
     ConsumerConfiguration consumerConfigs = {
@@ -128,6 +130,7 @@ function stringMaxLengthConstraintConsumerRecordTest() returns error? {
 @test:Config {enable: true}
 function floatMaxValueConstraintPayloadTest() returns error? {
     string topic = "float-max-value-constraint-consumer-record-test-topic";
+    kafkaTopics.push(topic);
     check sendMessage(1010.45, topic);
 
     ConsumerConfiguration consumerConfigs = {
@@ -150,6 +153,7 @@ function floatMaxValueConstraintPayloadTest() returns error? {
 @test:Config {enable: true}
 function arrayMaxLengthConstraintPayloadTest() returns error? {
     string topic = "array-max-length-constraint-payload-test-topic";
+    kafkaTopics.push(topic);
     check sendMessage([1, 2, 3, 4, 5, 6], topic);
 
     ConsumerConfiguration consumerConfigs = {
@@ -172,6 +176,7 @@ function arrayMaxLengthConstraintPayloadTest() returns error? {
 @test:Config {enable: true}
 function arrayMinLengthConstraintPayloadTest() returns error? {
     string topic = "array-min-length-constraint-payload-test-topic";
+    kafkaTopics.push(topic);
     check sendMessage([1], topic);
 
     ConsumerConfiguration consumerConfigs = {
@@ -194,6 +199,7 @@ function arrayMinLengthConstraintPayloadTest() returns error? {
 @test:Config {enable: true}
 function floatMinValueConstraintPayloadTest() returns error? {
     string topic = "float-min-value-constraint-consumer-record-test-topic";
+    kafkaTopics.push(topic);
     check sendMessage(1.45, topic);
 
     ConsumerConfiguration consumerConfigs = {
@@ -216,6 +222,7 @@ function floatMinValueConstraintPayloadTest() returns error? {
 @test:Config {enable: true}
 function intMaxValueConstraintListenerConsumerRecordTest() returns error? {
     string topic = "int-max-value-constraint-listener-test-topic";
+    kafkaTopics.push(topic);
     check sendMessage(1000, topic);
 
     Service intConstraintService =
@@ -250,6 +257,7 @@ function intMaxValueConstraintListenerConsumerRecordTest() returns error? {
 @test:Config {enable: true}
 function intMinValueConstraintListenerConsumerRecordTest() returns error? {
     string topic = "int-min-value-constraint-listener-test-topic";
+    kafkaTopics.push(topic);
     check sendMessage(8, topic);
 
     Service intConstraintService =
@@ -284,6 +292,7 @@ function intMinValueConstraintListenerConsumerRecordTest() returns error? {
 @test:Config {enable: true}
 function numberMaxValueConstraintListenerPayloadTest() returns error? {
     string topic = "number-max-value-constraint-listener-payload-test-topic";
+    kafkaTopics.push(topic);
     check sendMessage(1000.456, topic);
 
     Service intConstraintService =
@@ -318,6 +327,7 @@ function numberMaxValueConstraintListenerPayloadTest() returns error? {
 @test:Config {enable: true}
 function numberMinValueConstraintListenerPayloadTest() returns error? {
     string topic = "number-min-value-constraint-listener-payload-test-topic";
+    kafkaTopics.push(topic);
     check sendMessage(3.456, topic);
 
     Service intConstraintService =
@@ -352,6 +362,7 @@ function numberMinValueConstraintListenerPayloadTest() returns error? {
 @test:Config {enable: true}
 function validRecordConstraintPayloadTest() returns error? {
     string topic = "valid-record-constraint-listener-payload-test-topic";
+    kafkaTopics.push(topic);
     check sendMessage({name: "Phil Dunphy", age: 56}, topic);
     check sendMessage({name: "Claire Dunphy", age: 55}, topic);
     check sendMessage({name: "Hayley Dunphy", age: 20}, topic);
@@ -389,6 +400,7 @@ function validRecordConstraintPayloadTest() returns error? {
 @test:Config {enable: true}
 function disabledConstraintValidationTest() returns error? {
     string topic = "disabled-constraint-validation-test-topic";
+    kafkaTopics.push(topic);
     check sendMessage("This is a long message", topic);
     check sendMessage("Short msg", topic, "this-is-a-long-long-key");
 
@@ -416,6 +428,7 @@ function disabledConstraintValidationTest() returns error? {
 @test:Config {enable: true}
 function constraintErrorWithSeekConsumerRecordTest() returns error? {
     string topic = "constraint-error-with-seek-test-topic";
+    kafkaTopics.push(topic);
     check sendMessage("This is a valid message", topic);
     check sendMessage("Invalid", topic);
     check sendMessage("This is the second valid message", topic);
@@ -458,6 +471,7 @@ function constraintErrorWithSeekConsumerRecordTest() returns error? {
 @test:Config {enable: true}
 function invalidRecordConstraintWithSeekPayloadTest() returns error? {
     string topic = "invalid-record-constraint-with-seek-listener-test-topic";
+    kafkaTopics.push(topic);
     check sendMessage({name: "Phil Dunphy", age: 56}, topic);
     check sendMessage({name: "Claire Dunphy", age: 150}, topic);
     check sendMessage({name: "Hayley Dunphy", age: 20}, topic);

--- a/ballerina/tests/consumer_data_binding_test.bal
+++ b/ballerina/tests/consumer_data_binding_test.bal
@@ -20,6 +20,7 @@ import ballerina/log;
 @test:Config {enable: true}
 function stringBindingConsumerTest() returns error? {
     string topic = "string-binding-consumer-test-topic";
+    kafkaTopics.push(topic);
     check sendMessage(TEST_MESSAGE.toBytes(), topic);
     check sendMessage(TEST_MESSAGE.toBytes(), topic);
     check sendMessage(TEST_MESSAGE.toBytes(), topic);
@@ -42,6 +43,7 @@ function stringBindingConsumerTest() returns error? {
 @test:Config {enable: true}
 function intBindingConsumerTest() returns error? {
     string topic = "int-binding-consumer-test-topic";
+    kafkaTopics.push(topic);
     int sendingValue = 100;
     check sendMessage(sendingValue.toString().toBytes(), topic);
     check sendMessage(sendingValue.toString().toBytes(), topic);
@@ -65,6 +67,7 @@ function intBindingConsumerTest() returns error? {
 @test:Config {enable: true}
 function floatBindingConsumerTest() returns error? {
     string topic = "float-binding-consumer-test-topic";
+    kafkaTopics.push(topic);
     float sendingValue = 100.9;
     check sendMessage(sendingValue.toString().toBytes(), topic);
     check sendMessage(sendingValue.toString().toBytes(), topic);
@@ -88,6 +91,7 @@ function floatBindingConsumerTest() returns error? {
 @test:Config {enable: true}
 function decimalBindingConsumerTest() returns error? {
     string topic = "decimal-binding-consumer-test-topic";
+    kafkaTopics.push(topic);
     decimal sendingValue = 10.4d;
     check sendMessage(sendingValue.toString().toBytes(), topic);
     check sendMessage(sendingValue.toString().toBytes(), topic);
@@ -111,6 +115,7 @@ function decimalBindingConsumerTest() returns error? {
 @test:Config {enable: true}
 function booleanBindingConsumerTest() returns error? {
     string topic = "boolean-binding-consumer-test-topic";
+    kafkaTopics.push(topic);
     boolean sendingValue = true;
     check sendMessage(sendingValue.toString().toBytes(), topic);
     check sendMessage(sendingValue.toString().toBytes(), topic);
@@ -134,6 +139,7 @@ function booleanBindingConsumerTest() returns error? {
 @test:Config {enable: true}
 function xmlBindingConsumerTest() returns error? {
     string topic = "xml-binding-consumer-test-topic";
+    kafkaTopics.push(topic);
     xml sendingValue = xml `<start><Person><name>wso2</name><location>col-03</location></Person><Person><name>wso2</name><location>col-03</location></Person></start>`;
     check sendMessage(sendingValue, topic);
     check sendMessage(sendingValue, topic);
@@ -157,6 +163,7 @@ function xmlBindingConsumerTest() returns error? {
 @test:Config {enable: true}
 function jsonBindingConsumerTest() returns error? {
     string topic = "json-binding-consumer-test-topic";
+    kafkaTopics.push(topic);
     check sendMessage(jsonData.toString().toBytes(), topic);
     check sendMessage(jsonData.toString().toBytes(), topic);
     check sendMessage(jsonData.toString().toBytes(), topic);
@@ -179,6 +186,7 @@ function jsonBindingConsumerTest() returns error? {
 @test:Config {enable: true}
 function mapBindingConsumerTest() returns error? {
     string topic = "map-binding-consumer-test-topic";
+    kafkaTopics.push(topic);
     check sendMessage(personMap.toString().toBytes(), topic);
     check sendMessage(personMap.toString().toBytes(), topic);
     check sendMessage(personMap.toString().toBytes(), topic);
@@ -201,6 +209,7 @@ function mapBindingConsumerTest() returns error? {
 @test:Config {enable: true}
 function tableBindingConsumerTest() returns error? {
     string topic = "table-binding-consumer-test-topic";
+    kafkaTopics.push(topic);
     table<Person> personMapTable = table [];
 
     personMapTable.add(personRecord1);
@@ -226,6 +235,7 @@ function tableBindingConsumerTest() returns error? {
 @test:Config {enable: true}
 function recordBindingConsumerTest() returns error? {
     string topic = "record-binding-consumer-test-topic";
+    kafkaTopics.push(topic);
     check sendMessage(personRecord1.toString().toBytes(), topic);
     check sendMessage(personRecord1.toString().toBytes(), topic);
     check sendMessage(personRecord1.toString().toBytes(), topic);
@@ -248,6 +258,7 @@ function recordBindingConsumerTest() returns error? {
 @test:Config {enable: true}
 function nilBindingConsumerTest() returns error? {
     string topic = "nil-binding-consumer-test-topic";
+    kafkaTopics.push(topic);
     check sendMessage((), topic);
     check sendMessage((), topic);
     check sendMessage((), topic);
@@ -267,6 +278,7 @@ function nilBindingConsumerTest() returns error? {
 @test:Config {enable: true}
 function dataBindingErrorConsumerTest() returns error? {
     string topic = "data-binding-error-consumer-test-topic";
+    kafkaTopics.push(topic);
     check sendMessage(personRecord1.toString().toBytes(), topic);
     check sendMessage(personRecord1.toString().toBytes(), topic);
     check sendMessage(personRecord1.toString().toBytes(), topic);
@@ -290,6 +302,7 @@ function dataBindingErrorConsumerTest() returns error? {
 @test:Config {enable: true}
 function stringConsumerRecordTest() returns error? {
     string topic = "string-consumer-record-test-topic";
+    kafkaTopics.push(topic);
     check sendMessage(TEST_MESSAGE.toBytes(), topic);
     check sendMessage(TEST_MESSAGE.toBytes(), topic);
     check sendMessage(TEST_MESSAGE.toBytes(), topic);
@@ -313,6 +326,7 @@ function stringConsumerRecordTest() returns error? {
 @test:Config {enable: true}
 function intConsumerRecordTest() returns error? {
     string topic = "int-consumer-record-test-topic";
+    kafkaTopics.push(topic);
     check sendMessage(1.toString().toBytes(), topic);
     check sendMessage(1.toString().toBytes(), topic);
     check sendMessage(1.toString().toBytes(), topic);
@@ -336,6 +350,7 @@ function intConsumerRecordTest() returns error? {
 @test:Config {enable: true}
 function xmlConsumerRecordTest() returns error? {
     string topic = "xml-consumer-record-test-topic";
+    kafkaTopics.push(topic);
     xml sendingValue = xml `<start><Person><name>wso2</name><location>col-03</location></Person><Person><name>wso2</name><location>col-03</location></Person></start>`;
     check sendMessage(sendingValue.toString().toBytes(), topic);
     check sendMessage(sendingValue.toString().toBytes(), topic);
@@ -360,6 +375,7 @@ function xmlConsumerRecordTest() returns error? {
 @test:Config {enable: true}
 function recordConsumerRecordTest() returns error? {
     string topic = "record-consumer-record-test-topic";
+    kafkaTopics.push(topic);
     check sendMessage(personRecord1.toString().toBytes(), topic);
     check sendMessage(personRecord1.toString().toBytes(), topic);
     check sendMessage(personRecord1.toString().toBytes(), topic);
@@ -383,6 +399,7 @@ function recordConsumerRecordTest() returns error? {
 @test:Config {enable: true}
 function jsonConsumerRecordTest() returns error? {
     string topic = "json-consumer-record-test-topic";
+    kafkaTopics.push(topic);
     check sendMessage(jsonData.toString().toBytes(), topic);
     check sendMessage(jsonData.toString().toBytes(), topic);
     check sendMessage(jsonData.toString().toBytes(), topic);
@@ -406,6 +423,7 @@ function jsonConsumerRecordTest() returns error? {
 @test:Config {enable: true}
 function readonlyConsumerRecordTest() returns error? {
     string topic = "readonly-consumer-record-test-topic";
+    kafkaTopics.push(topic);
     check sendMessage(personRecord1.toString().toBytes(), topic);
     check sendMessage(personRecord1.toString().toBytes(), topic);
     check sendMessage(personRecord1.toString().toBytes(), topic);
@@ -429,6 +447,7 @@ function readonlyConsumerRecordTest() returns error? {
 @test:Config {enable: true}
 function unionBindingConsumerTest() returns error? {
     string topic = "union-binding-consumer-test-topic";
+    kafkaTopics.push(topic);
     check sendMessage(TEST_MESSAGE.toBytes(), topic);
     check sendMessage(TEST_MESSAGE.toBytes(), topic);
     check sendMessage(TEST_MESSAGE.toBytes(), topic);
@@ -451,6 +470,7 @@ function unionBindingConsumerTest() returns error? {
 @test:Config {enable: true}
 function readonlyRecordBindingConsumerTest() returns error? {
     string topic = "readonly-record-binding-consumer-test-topic";
+    kafkaTopics.push(topic);
     check sendMessage(personRecord1.toString().toBytes(), topic);
     check sendMessage(personRecord1.toString().toBytes(), topic);
     check sendMessage(personRecord1.toString().toBytes(), topic);
@@ -474,6 +494,7 @@ function readonlyRecordBindingConsumerTest() returns error? {
 @test:Config {enable: true}
 function pollErrorWithSeekConsumerRecordTest() returns error? {
     string topic = "poll-error-with-seek-test-topic";
+    kafkaTopics.push(topic);
     check sendMessage(personRecord1, topic);
     check sendMessage("Invalid", topic);
     check sendMessage(personRecord1, topic);

--- a/ballerina/tests/listener_client_tests.bal
+++ b/ballerina/tests/listener_client_tests.bal
@@ -36,6 +36,7 @@ int receivedMsgCount = 0;
 @test:Config {enable: true}
 function consumerServiceTest() returns error? {
     string topic = "service-test-topic";
+    kafkaTopics.push(topic);
     check sendMessage(TEST_MESSAGE.toBytes(), topic);
     ConsumerConfiguration consumerConfiguration = {
         topics: [topic],
@@ -55,6 +56,7 @@ function consumerServiceTest() returns error? {
 @test:Config {enable: true}
 function consumerServiceInvalidUrlTest() returns error? {
     string topic = "consumer-service-invalid-topic";
+    kafkaTopics.push(topic);
     check sendMessage(TEST_MESSAGE.toBytes(), topic);
     ConsumerConfiguration consumerConfiguration = {
         topics: [topic],
@@ -74,6 +76,7 @@ function consumerServiceInvalidUrlTest() returns error? {
 @test:Config {enable: true}
 function attachDetachToClosedListenerTest() returns error? {
     string topic = "attach-detach-closed-listener-topic";
+    kafkaTopics.push(topic);
     check sendMessage(TEST_MESSAGE.toBytes(), topic);
     ConsumerConfiguration consumerConfiguration = {
         topics: [topic],
@@ -127,6 +130,7 @@ function attachDetachToClosedListenerTest() returns error? {
 @test:Config {enable: true}
 function consumerServiceGracefulStopTest() returns error? {
     string topic = "listener-graceful-stop-test-topic";
+    kafkaTopics.push(topic);
     check sendMessage(TEST_MESSAGE.toBytes(), topic);
     ConsumerConfiguration consumerConfiguration = {
         topics: [topic],
@@ -149,6 +153,7 @@ function consumerServiceGracefulStopTest() returns error? {
 @test:Config {enable: true}
 function consumerServiceImmediateStopTest() returns error? {
     string topic = "listener-immediate-stop-test-topic";
+    kafkaTopics.push(topic);
     check sendMessage(TEST_MESSAGE.toBytes(), topic);
     ConsumerConfiguration consumerConfiguration = {
         topics: [topic],
@@ -171,6 +176,7 @@ function consumerServiceImmediateStopTest() returns error? {
 @test:Config {enable: true}
 function consumerServiceSubscribeErrorTest() returns error? {
     string topic = "listener-subscribe-error-test-topic";
+    kafkaTopics.push(topic);
     check sendMessage(TEST_MESSAGE.toBytes(), topic);
     ConsumerConfiguration consumerConfiguration = {
         topics: [topic],
@@ -208,6 +214,7 @@ function consumerServiceSubscribeErrorTest() returns error? {
 @test:Config {enable: true}
 function listenerConfigTest() returns error? {
     string topic = "listener-config-test-topic";
+    kafkaTopics.push(topic);
     ConsumerConfiguration consumerConfiguration = {
         topics: [topic],
         offsetReset: OFFSET_RESET_EARLIEST,
@@ -268,6 +275,7 @@ function listenerConfigErrorTest() returns error? {
 }
 function consumerServiceCommitOffsetTest() returns error? {
     string topic = "listener-commit-offset-test-topic";
+    kafkaTopics.push(topic);
     ConsumerConfiguration consumerConfiguration = {
         topics: [topic],
         offsetReset: OFFSET_RESET_EARLIEST,
@@ -303,6 +311,7 @@ function consumerServiceCommitOffsetTest() returns error? {
 @test:Config {enable: true}
 function consumerServiceCommitTest() returns error? {
     string topic = "listener-commit-test-topic";
+    kafkaTopics.push(topic);
     ConsumerConfiguration consumerConfiguration = {
         topics: [topic],
         offsetReset: OFFSET_RESET_EARLIEST,
@@ -338,6 +347,7 @@ function consumerServiceCommitTest() returns error? {
 @test:Config {enable: true}
 function saslListenerTest() returns error? {
     string topic = "sasl-listener-test-topic";
+    kafkaTopics.push(topic);
 
     ConsumerConfiguration consumerConfig = {
         groupId:"listener-sasl-test-group",
@@ -387,6 +397,7 @@ function saslListenerIncorrectCredentialsTest() returns error? {
 @test:Config {enable: true}
 function sslListenerTest() returns error? {
     string topic = "ssl-listener-test-topic";
+    kafkaTopics.push(topic);
 
     ConsumerConfiguration consumerConfig = {
         groupId:"listener-sasl-test-group",
@@ -409,6 +420,7 @@ function sslListenerTest() returns error? {
 @test:Config {enable: true}
 function basicMessageOrderTest() returns error? {
     string topic = "message-order-test-topic";
+    kafkaTopics.push(topic);
     int i = 0;
     while (i < 5) {
         string message = i.toString();
@@ -441,6 +453,7 @@ function basicMessageOrderTest() returns error? {
 @test:Config {enable: true}
 function listenerDetachTest() returns error? {
     string topic1 = "listener-detach-test-topic";
+    kafkaTopics.push(topic1);
     ConsumerConfiguration consumerConfiguration1 = {
         topics: [topic1],
         offsetReset: OFFSET_RESET_EARLIEST,
@@ -480,6 +493,7 @@ function listenerDetachTest() returns error? {
 
     // Attach a new listener to the same service and test for messages
     string topic2 = "listener2-detach-test-topic";
+    kafkaTopics.push(topic2);
     ConsumerConfiguration consumerConfiguration2 = {
         topics: [topic2],
         offsetReset: OFFSET_RESET_EARLIEST,
@@ -499,6 +513,7 @@ function listenerDetachTest() returns error? {
 @test:Config {enable: true}
 function plaintextToSecuredEndpointsListenerTest() returns error? {
     string topic = "plaintext-secured-endpoints-listener-test-topic";
+    kafkaTopics.push(topic);
 
     ConsumerConfiguration consumerConfiguration = {
         topics: [topic],
@@ -535,7 +550,7 @@ function plaintextToSecuredEndpointsListenerTest() returns error? {
 @test:Config {enable: true}
 function invalidSecuredEndpointsListenerTest() returns error? {
     string topic = "invalid-secured-endpoints-listener-test-topic";
-
+    kafkaTopics.push(topic);
     check sendMessage(TEST_MESSAGE.toBytes(), topic);
 
     ConsumerConfiguration consumerConfiguration = {
@@ -943,6 +958,7 @@ service object {
 @test:Config {enable: true}
 function listenerWithPollTimeoutConfigTest() returns error? {
     string topic = "listener-poll-timeout-config-test-topic";
+    kafkaTopics.push(topic);
     check sendMessage(TEST_MESSAGE, topic);
     check sendMessage(TEST_MESSAGE, topic);
 

--- a/ballerina/tests/listener_data_binding_tests.bal
+++ b/ballerina/tests/listener_data_binding_tests.bal
@@ -173,6 +173,7 @@ PayloadConsumerRecord payloadConsumerRecord = {
 @test:Config {enable: true}
 function dataBindingErrorListenerTest() returns error? {
     string topic = "data-binding-error-listener-test-topic";
+    kafkaTopics.push(topic);
     check sendMessage(jsonData, topic);
     check sendMessage(jsonData, topic);
     check sendMessage(jsonData, topic);
@@ -212,6 +213,7 @@ function dataBindingErrorListenerTest() returns error? {
 @test:Config {enable: true}
 function intConsumerRecordBindingListenerTest() returns error? {
     string topic = "int-consumer-record-listener-test-topic";
+    kafkaTopics.push(topic);
     check sendMessage(1, topic);
 
     Service intBindingService =
@@ -246,6 +248,7 @@ function intConsumerRecordBindingListenerTest() returns error? {
 @test:Config {enable: true}
 function floatConsumerRecordBindingListenerTest() returns error? {
     string topic = "float-consumer-record-listener-test-topic";
+    kafkaTopics.push(topic);
     check sendMessage(10.5, topic);
 
     Service floatBindingService =
@@ -280,6 +283,7 @@ function floatConsumerRecordBindingListenerTest() returns error? {
 @test:Config {enable: true}
 function decimalConsumerRecordBindingListenerTest() returns error? {
     string topic = "decimal-consumer-record-listener-test-topic";
+    kafkaTopics.push(topic);
     check sendMessage(98.5d, topic);
 
     Service decimalBindingService =
@@ -314,6 +318,7 @@ function decimalConsumerRecordBindingListenerTest() returns error? {
 @test:Config {enable: true}
 function booleanConsumerRecordBindingListenerTest() returns error? {
     string topic = "boolean-consumer-record-listener-test-topic";
+    kafkaTopics.push(topic);
     check sendMessage(true, topic);
 
     Service booleanBindingService =
@@ -348,6 +353,7 @@ function booleanConsumerRecordBindingListenerTest() returns error? {
 @test:Config {enable: true}
 function stringConsumerRecordListenerTest() returns error? {
     string topic = "string-consumer-record-listener-test-topic";
+    kafkaTopics.push(topic);
     check sendMessage(TEST_MESSAGE, topic);
     check sendMessage(TEST_MESSAGE, topic);
     check sendMessage(TEST_MESSAGE, topic);
@@ -384,6 +390,7 @@ function stringConsumerRecordListenerTest() returns error? {
 @test:Config {enable: true}
 function xmlConsumerRecordListenerTest() returns error? {
     string topic = "xml-consumer-record-listener-test-topic";
+    kafkaTopics.push(topic);
     xml xmlData = xml `<start><Person><name>wso2</name><location>col-03</location></Person><Person><name>wso2</name><location>col-03</location></Person></start>`;
     check sendMessage(xmlData, topic);
     check sendMessage(xmlData, topic);
@@ -421,6 +428,7 @@ function xmlConsumerRecordListenerTest() returns error? {
 @test:Config {enable: true}
 function recordConsumerRecordListenerTest() returns error? {
     string topic = "record-consumer-record-listener-test-topic";
+    kafkaTopics.push(topic);
     check sendMessage(personRecord1, topic);
     check sendMessage(personRecord1, topic);
     check sendMessage(personRecord1, topic);
@@ -457,6 +465,7 @@ function recordConsumerRecordListenerTest() returns error? {
 @test:Config {enable: true}
 function mapConsumerRecordListenerTest() returns error? {
     string topic = "map-consumer-record-listener-test-topic";
+    kafkaTopics.push(topic);
     check sendMessage(personMap, topic);
     check sendMessage(personMap, topic);
     check sendMessage(personMap, topic);
@@ -493,6 +502,7 @@ function mapConsumerRecordListenerTest() returns error? {
 @test:Config {enable: true}
 function tableConsumerRecordListenerTest() returns error? {
     string topic = "table-consumer-record-listener-test-topic";
+    kafkaTopics.push(topic);
     table<Person> personMapTable = table [];
 
     personMapTable.add(personRecord1);
@@ -532,6 +542,7 @@ function tableConsumerRecordListenerTest() returns error? {
 @test:Config {enable: true}
 function jsonConsumerRecordListenerTest() returns error? {
     string topic = "json-consumer-record-listener-test-topic";
+    kafkaTopics.push(topic);
     check sendMessage(jsonData, topic);
     check sendMessage(jsonData, topic);
     check sendMessage(jsonData, topic);
@@ -568,6 +579,7 @@ function jsonConsumerRecordListenerTest() returns error? {
 @test:Config {enable: true}
 function readonlyConsumerRecordListenerTest() returns error? {
     string topic = "readonly-consumer-record-listener-test-topic";
+    kafkaTopics.push(topic);
     check sendMessage(personRecord1, topic);
     check sendMessage(personRecord1, topic);
     check sendMessage(personRecord1, topic);
@@ -607,6 +619,7 @@ function readonlyConsumerRecordListenerTest() returns error? {
 @test:Config {enable: true}
 function intPayloadBindingListenerTest() returns error? {
     string topic = "int-payload-listener-test-topic";
+    kafkaTopics.push(topic);
     check sendMessage(1, topic);
 
     Service intBindingService =
@@ -641,6 +654,7 @@ function intPayloadBindingListenerTest() returns error? {
 @test:Config {enable: true}
 function floatPayloadBindingListenerTest() returns error? {
     string topic = "float-payload-listener-test-topic";
+    kafkaTopics.push(topic);
     check sendMessage(10.5, topic);
 
     Service floatBindingService =
@@ -675,6 +689,7 @@ function floatPayloadBindingListenerTest() returns error? {
 @test:Config {enable: true}
 function decimalPayloadBindingListenerTest() returns error? {
     string topic = "decimal-payload-listener-test-topic";
+    kafkaTopics.push(topic);
     check sendMessage(98.5d, topic);
 
     Service decimalBindingService =
@@ -709,6 +724,7 @@ function decimalPayloadBindingListenerTest() returns error? {
 @test:Config {enable: true}
 function booleanPayloadBindingListenerTest() returns error? {
     string topic = "boolean-payload-listener-test-topic";
+    kafkaTopics.push(topic);
     check sendMessage(true, topic);
 
     Service booleanBindingService =
@@ -743,6 +759,7 @@ function booleanPayloadBindingListenerTest() returns error? {
 @test:Config {enable: true}
 function stringPayloadListenerTest() returns error? {
     string topic = "string-payload-listener-test-topic";
+    kafkaTopics.push(topic);
     check sendMessage(TEST_MESSAGE, topic);
     check sendMessage(TEST_MESSAGE, topic);
     check sendMessage(TEST_MESSAGE, topic);
@@ -779,6 +796,7 @@ function stringPayloadListenerTest() returns error? {
 @test:Config {enable: true}
 function xmlPayloadListenerTest() returns error? {
     string topic = "xml-payload-listener-test-topic";
+    kafkaTopics.push(topic);
     xml xmlData = xml `<start><Person><name>wso2</name><location>col-03</location></Person><Person><name>wso2</name><location>col-03</location></Person></start>`;
     check sendMessage(xmlData, topic);
     check sendMessage(xmlData, topic);
@@ -816,6 +834,7 @@ function xmlPayloadListenerTest() returns error? {
 @test:Config {enable: true}
 function recordPayloadListenerTest() returns error? {
     string topic = "record-payload-listener-test-topic";
+    kafkaTopics.push(topic);
     check sendMessage(personRecord1, topic);
     check sendMessage(personRecord1, topic);
     check sendMessage(personRecord1, topic);
@@ -852,6 +871,7 @@ function recordPayloadListenerTest() returns error? {
 @test:Config {enable: true}
 function mapPayloadListenerTest() returns error? {
     string topic = "map-payload-listener-test-topic";
+    kafkaTopics.push(topic);
     check sendMessage(personMap, topic);
     check sendMessage(personMap, topic);
     check sendMessage(personMap, topic);
@@ -888,6 +908,7 @@ function mapPayloadListenerTest() returns error? {
 @test:Config {enable: true}
 function tablePayloadListenerTest() returns error? {
     string topic = "table-payload-listener-test-topic";
+    kafkaTopics.push(topic);
     table<Person> personMapTable = table [];
 
     personMapTable.add(personRecord1);
@@ -927,6 +948,7 @@ function tablePayloadListenerTest() returns error? {
 @test:Config {enable: true}
 function jsonPayloadListenerTest() returns error? {
     string topic = "json-payload-listener-test-topic";
+    kafkaTopics.push(topic);
     check sendMessage(jsonData, topic);
     check sendMessage(jsonData, topic);
     check sendMessage(jsonData, topic);
@@ -963,6 +985,7 @@ function jsonPayloadListenerTest() returns error? {
 @test:Config {enable: true}
 function payloadConsumerRecordListenerTest() returns error? {
     string topic = "payload-consumer-record-listener-test-topic";
+    kafkaTopics.push(topic);
     check sendMessage(payloadConsumerRecord, topic);
     check sendMessage(payloadConsumerRecord, topic);
     check sendMessage(payloadConsumerRecord, topic);
@@ -999,6 +1022,7 @@ function payloadConsumerRecordListenerTest() returns error? {
 @test:Config {enable: true}
 function readonlyPayloadListenerTest() returns error? {
     string topic = "readonly-payload-listener-test-topic";
+    kafkaTopics.push(topic);
     isPayloadReadonly = false;
     readOnlyPayloads = [];
     check sendMessage(personRecord1, topic);
@@ -1040,6 +1064,7 @@ function readonlyPayloadListenerTest() returns error? {
 @test:Config {enable: true}
 function readonlyPayloadWithPayloadAnnotationListenerTest() returns error? {
     string topic = "readonly-payload-consumer-record-with-annotation-record-listener-test-topic";
+    kafkaTopics.push(topic);
 
     isPayloadReadonly = false;
     readOnlyPayloads = [];
@@ -1083,6 +1108,7 @@ function readonlyPayloadWithPayloadAnnotationListenerTest() returns error? {
 @test:Config {enable: true}
 function readonlyPayloadReadonlyConsumerRecordsListenerTest() returns error? {
     string topic = "readonly-payload-with-readonly-consumer-records-listener-test-topic";
+    kafkaTopics.push(topic);
 
     isPayloadReadonly = false;
     readOnlyPayloads = [];
@@ -1126,6 +1152,7 @@ function readonlyPayloadReadonlyConsumerRecordsListenerTest() returns error? {
 @test:Config {enable: true}
 function invalidRecordPayloadWithSeekListenerTest() returns error? {
     string topic = "invalid-record-payload-with-seek-listener-test-topic";
+    kafkaTopics.push(topic);
     check sendMessage(personRecord1, topic);
     check sendMessage("Invalid", topic);
     check sendMessage(personRecord1, topic);

--- a/ballerina/tests/producer_client_tests.bal
+++ b/ballerina/tests/producer_client_tests.bal
@@ -74,6 +74,7 @@ function producerInitTest() returns error? {
 @test:Config {enable: true}
 function producerSendStringTest() returns error? {
     string topic = "send-string-test-topic";
+    kafkaTopics.push(topic);
     Producer stringProducer = check new (DEFAULT_URL, producerConfiguration);
     string message = "Hello, Ballerina";
     Error? result = stringProducer->send({ topic: topic, value: message.toBytes() });
@@ -117,6 +118,7 @@ function producerKeyTypeMismatchErrorTest() returns error? {
 }
 function producerCloseTest() returns error? {
     string topic = "producer-close-test-topic";
+    kafkaTopics.push(topic);
     Producer producer = check new (DEFAULT_URL, producerConfiguration);
     string message = "Test Message";
     Error? result = producer->send({ topic: topic, value: message.toBytes() });
@@ -135,6 +137,7 @@ function producerCloseTest() returns error? {
 @test:Config {enable: true}
 function producerFlushTest() returns error? {
     string topic = "producer-flush-test-topic";
+    kafkaTopics.push(topic);
     Producer producer = check new (DEFAULT_URL, producerConfiguration);
     check producer->send({ topic: topic, value: TEST_MESSAGE.toBytes() });
     check producer->'flush();
@@ -155,6 +158,7 @@ function producerFlushTest() returns error? {
 @test:Config {enable: true}
 function producerGetTopicPartitionsTest() returns error? {
     string topic = "get-topic-partitions-test-topic";
+    kafkaTopics.push(topic);
     Producer producer = check new (DEFAULT_URL, producerConfiguration);
     TopicPartition[] topicPartitions = check producer->getTopicPartitions(topic);
     test:assertEquals(topicPartitions[0].partition, 0, "Expected: 0. Received: " + topicPartitions[0].partition.toString());
@@ -179,6 +183,7 @@ function producerGetTopicPartitionsErrorTest() returns error? {
 @test:Config {enable: true}
 function transactionalProducerTest() returns error? {
     string topic = "transactional-producer-test-topic";
+    kafkaTopics.push(topic);
     ProducerConfiguration producerConfigs = {
         clientId: "test-producer-05",
         acks: "all",
@@ -215,6 +220,7 @@ function transactionalProducerTest() returns error? {
 @test:Config {enable: true}
 function transactionalProducerWithAbortTest() returns error? {
     string topic = "rollback-producer-test-topic";
+    kafkaTopics.push(topic);
     ProducerConfiguration producerConfigs = {
         clientId: "test-producer-05",
         acks: "all",
@@ -268,6 +274,7 @@ isolated function failTransaction() returns error {
 @test:Config{enable: true}
 function saslProducerTest() returns error? {
     string topic = "sasl-producer-test-topic";
+    kafkaTopics.push(topic);
 
     ProducerConfiguration producerConfigs = {
         clientId: "test-producer-06",
@@ -300,6 +307,7 @@ function saslProducerTest() returns error? {
 @test:Config{enable: true}
 function saslProducerIncorrectCredentialsTest() returns error? {
     string topic = "sasl-producer-incorrect-credentials-test-topic";
+    kafkaTopics.push(topic);
     AuthenticationConfiguration invalidAuthConfig = {
         mechanism: AUTH_SASL_PLAIN,
         username: SASL_USER,
@@ -339,6 +347,7 @@ function saslProducerIncorrectCredentialsTest() returns error? {
 @test:Config {enable: true}
 function producerAdditionalPropertiesTest() returns error? {
     string topic = "producer-additional-properties-test-topic";
+    kafkaTopics.push(topic);
     map<string> propertyMap = {
         "security.protocol": PROTOCOL_SASL_PLAINTEXT
     };
@@ -373,6 +382,7 @@ function producerAdditionalPropertiesTest() returns error? {
 @test:Config {enable: true}
 function sslProducerTest() returns error? {
     string topic = "ssl-producer-test-topic";
+    kafkaTopics.push(topic);
 
     ProducerConfiguration producerConfiguration = {
         clientId: "test-producer-09",
@@ -402,6 +412,7 @@ function sslProducerTest() returns error? {
 @test:Config {enable: true}
 function sslCertKeyProducerTest() returns error? {
     string topic = "ssl-cert-key-producer-test-topic";
+    kafkaTopics.push(topic);
 
     CertKey certKey = {
         certFile: SSL_CLIENT_PUBLIC_CERT_FILE_PATH,
@@ -444,6 +455,7 @@ function sslCertKeyProducerTest() returns error? {
 @test:Config {enable: true}
 function sslCertOnlyProducerTest() returns error? {
     string topic = "ssl-cert-only-producer-test-topic";
+    kafkaTopics.push(topic);
 
     SecureSocket certSocket = {
         cert: SSL_BROKER_PUBLIC_CERT_FILE_PATH,
@@ -480,6 +492,7 @@ function sslCertOnlyProducerTest() returns error? {
 @test:Config {enable: true}
 function SSLWithSASLAuthProducerTest() returns error? {
     string topic = "ssl-with-sasl-auth-producer-test-topic";
+    kafkaTopics.push(topic);
 
     SecureSocket certSocket = {
         cert: SSL_BROKER_PUBLIC_CERT_FILE_PATH,
@@ -573,6 +586,7 @@ function SASLOnSSLEndpointProducerTest() returns error? {
 @test:Config {enable: true}
 function operationsOnClosedProducerTest() returns error? {
     string topic = "operations-on-closed-producer";
+    kafkaTopics.push(topic);
     ProducerConfiguration producerConfiguration = {
         clientId: "test-producer-16"
     };

--- a/ballerina/tests/producer_data_binding_tests.bal
+++ b/ballerina/tests/producer_data_binding_tests.bal
@@ -80,6 +80,7 @@ public type JsonProducerRecord record {|
 @test:Config {enable: true}
 function intProduceTest() returns error? {
     string topic = "int-produce-test-topic";
+    kafkaTopics.push(topic);
     IntProducerRecord producerRecord = {
         topic,
         'key: 2,
@@ -115,6 +116,7 @@ function intProduceTest() returns error? {
 @test:Config {enable: true}
 function floatProduceTest() returns error? {
     string topic = "float-produce-test-topic";
+    kafkaTopics.push(topic);
     FloatProducerRecord producerRecord = {
         topic,
         'key: 100.9,
@@ -150,6 +152,7 @@ function floatProduceTest() returns error? {
 @test:Config {enable: true}
 function decimalProduceTest() returns error? {
     string topic = "decimal-produce-test-topic";
+    kafkaTopics.push(topic);
     DecimalProducerRecord producerRecord = {
         topic,
         'key: 2.3d,
@@ -185,6 +188,7 @@ function decimalProduceTest() returns error? {
 @test:Config {enable: true}
 function booleanProduceTest() returns error? {
     string topic = "boolean-produce-test-topic";
+    kafkaTopics.push(topic);
     BooleanProducerRecord producerRecord = {
         topic,
         'key: true,
@@ -218,6 +222,7 @@ function booleanProduceTest() returns error? {
 @test:Config {enable: true}
 function stringProduceTest() returns error? {
     string topic = "string-produce-test-topic";
+    kafkaTopics.push(topic);
     StringProducerRecord producerRecord = {
         topic,
         'key: TEST_KEY,
@@ -251,6 +256,7 @@ function stringProduceTest() returns error? {
 @test:Config {enable: true}
 function xmlProduceTest() returns error? {
     string topic = "xml-produce-test-topic";
+    kafkaTopics.push(topic);
     xml xmlData = xml `<start><Person><name>wso2</name><location>col-03</location></Person><Person><name>wso2</name><location>col-03</location></Person></start>`;
     XmlProducerRecord producerRecord = {
         topic,
@@ -285,6 +291,7 @@ function xmlProduceTest() returns error? {
 @test:Config {enable: true}
 function recordProduceTest() returns error? {
     string topic = "record-produce-test-topic";
+    kafkaTopics.push(topic);
     PersonProducerRecord producerRecord = {
         topic,
         value: personRecord1
@@ -315,6 +322,7 @@ function recordProduceTest() returns error? {
 @test:Config {enable: true}
 function mapProduceTest() returns error? {
     string topic = "map-produce-test-topic";
+    kafkaTopics.push(topic);
     MapProducerRecord producerRecord = {
         topic,
         value: personMap
@@ -345,6 +353,7 @@ function mapProduceTest() returns error? {
 @test:Config {enable: true}
 function tableProduceTest() returns error? {
     string topic = "table-produce-test-topic";
+    kafkaTopics.push(topic);
     table<Person> personMapTable = table [];
     personMapTable.add(personRecord1);
     TableProducerRecord producerRecord = {


### PR DESCRIPTION
## Purpose
The issue was due to the way of test ordering difference in old testerina implementation and new implementation. Now, the failing tests can calculate the topics dynamically and won't fail in both the implementations.
Tested with the testerina branch in lang as well

Fixes https://github.com/ballerina-platform/ballerina-standard-library/issues/3495
## Examples

## Checklist
- [x] Linked to an issue
- [ ] ~Updated the changelog~
- [ ] ~Added tests~
- [ ] ~Updated the spec~
- [ ] ~Checked native-image compatibility~
