### PR TITLE
[5.x] Change the partition value to a long when creating `kafka:TopicPartition`

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -4,6 +4,12 @@ This file contains all the notable changes done to the Ballerina Kafka package t
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+### Fixed
+- [Fixed `ClassCastException` when doing `commitOffset` with a polled offset value](https://github.com/ballerina-platform/ballerina-standard-library/issues/4424)
+
+## [3.7.0] - 2023-04-10
+
 ### Changed
 - [Exit the service when a panic occurs inside the service method](https://github.com/ballerina-platform/ballerina-standard-library/issues/4241)
 

--- a/native/src/main/java/io/ballerina/stdlib/kafka/utils/KafkaUtils.java
+++ b/native/src/main/java/io/ballerina/stdlib/kafka/utils/KafkaUtils.java
@@ -614,7 +614,7 @@ public class KafkaUtils {
 
         Object value = getValueWithIntendedType(valueType, (byte[]) record.value(), record, autoSeek);
         BMap<BString, Object> topicPartition = ValueCreator.createRecordValue(getTopicPartitionRecord(), record.topic(),
-                                                                              record.partition());
+                                                                              (long) record.partition());
         BMap<BString, Object> consumerRecord = ValueCreator.createRecordValue(recordType);
         consumerRecord.put(StringUtils.fromString(KAFKA_RECORD_KEY), key);
         consumerRecord.put(StringUtils.fromString(KAFKA_RECORD_VALUE), value);


### PR DESCRIPTION
## Purpose
$subject
Fixes https://github.com/ballerina-platform/ballerina-standard-library/issues/4424
## Examples

## Checklist
- [x] Linked to an issue
- [x] Updated the changelog
- [x] Added tests
- ~[ ] Updated the spec~
- [ ] Checked native-image compatibility
