### PR TITLE
Fix test failure due to the latest changes in the confluent docker images

### DIFF
--- a/ballerina/Dependencies.toml
+++ b/ballerina/Dependencies.toml
@@ -89,7 +89,7 @@ dependencies = [
 [[package]]
 org = "ballerina"
 name = "http"
-version = "2.14.0"
+version = "2.14.2"
 scope = "testOnly"
 dependencies = [
 	{org = "ballerina", name = "auth"},
@@ -411,7 +411,7 @@ modules = [
 [[package]]
 org = "ballerinax"
 name = "confluent.cavroserdes"
-version = "1.0.4"
+version = "1.0.2"
 dependencies = [
 	{org = "ballerina", name = "avro"},
 	{org = "ballerina", name = "jballerina.java"},

--- a/ballerina/tests/compose.yaml
+++ b/ballerina/tests/compose.yaml
@@ -1,6 +1,6 @@
 services:
     zookeeper-add-kafka-users:
-        image: 'confluentinc/cp-kafka:latest'
+        image: 'confluentinc/cp-kafka:7.9.2'
         container_name: "zookeeper-add-kafka-users"
         depends_on:
             - zookeeper
@@ -9,7 +9,7 @@ services:
                               kafka-configs --zookeeper zookeeper:2181 --alter --add-config 'SCRAM-SHA-256=[iterations=4096,password=scram256password]' --entity-type users --entity-name scram256user && \
                               kafka-configs --zookeeper zookeeper:2181 --alter --add-config 'SCRAM-SHA-512=[iterations=4096,password=scram512password]' --entity-type users --entity-name scram512user'"
     zookeeper:
-        image: 'confluentinc/cp-zookeeper:latest'
+        image: 'confluentinc/cp-zookeeper:7.9.2'
         hostname: zookeeper
         container_name: kafka-test-zookeeper
         ports:
@@ -21,7 +21,7 @@ services:
         volumes:
             - ./configs/zookeeper_jaas.conf:/opt/confluentinc/kafka/config/zookeeper_jaas.conf
     broker:
-        image: 'confluentinc/cp-server:latest'
+        image: 'confluentinc/cp-server:7.9.2'
         hostname: broker
         container_name: kafka-test-broker
         depends_on:
@@ -59,7 +59,7 @@ services:
             - ./secrets/trustoresandkeystores/kafka.broker.truststore.jks:/etc/kafka/secrets/kafka.broker.truststore.jks
             - ./configs/kafka_server_jaas.conf:/opt/confluentinc/kafka/config/kafka_server_jaas.conf
     schema-registry:
-        image: 'confluentinc/cp-schema-registry:latest'
+        image: 'confluentinc/cp-schema-registry:7.9.2'
         container_name: kafka-schema-registry
         depends_on:
             - broker


### PR DESCRIPTION
## Purpose

With the latest version - `8.0.0`, we should use KRaft Only – No More Apache ZooKeeper.

The actual fix should be updating the docker compose file with the relevant changes. This is added until we do that change

See release notes](https://docs.confluent.io/platform/current/release-notes/index.html and [blog ](http://confluent.io/blog/introducing-confluent-platform-8-0/?session_ref=https://www.google.com/&_ga=2.114134023.1484338301.1751534197-1289081629.1747809993&_gl=1*1dve1po*_gcl_au*MTE1OTY1MTIxLjE3NDc4MDk5OTM.*_ga*MTI4OTA4MTYyOS4xNzQ3ODA5OTkz*_ga_D2D3EGKSGD*czE3NTE1MzQxOTYkbzUkZzEkdDE3NTE1MzU0NTAkajQ5JGwwJGgw)

## Examples

## Checklist
- [ ] Linked to an issue
- [ ] Updated the changelog
- [ ] Added tests
- [ ] Updated the spec
- [ ] Checked native-image compatibility
