### PR TITLE
Fix `CVE-2026-35554` vulnerability

### DIFF
--- a/ballerina/Ballerina.toml
+++ b/ballerina/Ballerina.toml
@@ -1,7 +1,7 @@
 [package]
 org = "ballerinax"
 name = "kafka"
-version = "4.6.4"
+version = "4.6.5"
 authors = ["Ballerina"]
 keywords = ["kafka", "event streaming", "network", "messaging", "Vendor/Apache", "Area/Messaging", "Type/Connector", "Type/Trigger"]
 repository = "https://github.com/ballerina-platform/module-ballerinax-kafka"
@@ -15,20 +15,20 @@ graalvmCompatible = true
 [[platform.java21.dependency]]
 groupId = "io.ballerina.stdlib"
 artifactId = "kafka-native"
-version = "4.6.4"
-path = "../native/build/libs/kafka-native-4.6.4.jar"
+version = "4.6.5"
+path = "../native/build/libs/kafka-native-4.6.5-SNAPSHOT.jar"
 
 [[platform.java21.dependency]]
 groupId = "org.apache.kafka"
 artifactId = "kafka-clients"
-version = "3.9.1"
-path = "./lib/kafka-clients-3.9.1.jar"
+version = "3.9.2"
+path = "./lib/kafka-clients-3.9.2.jar"
 
 [[platform.java21.dependency]]
 groupId = "org.apache.kafka"
 artifactId = "kafka_2.12"
-version = "3.9.1"
-path = "./lib/kafka_2.12-3.9.1.jar"
+version = "3.9.2"
+path = "./lib/kafka_2.12-3.9.2.jar"
 
 [[platform.java21.dependency]]
 groupId = "io.ballerina.stdlib"

--- a/ballerina/CompilerPlugin.toml
+++ b/ballerina/CompilerPlugin.toml
@@ -3,4 +3,4 @@ id = "kafka-compiler-plugin"
 class = "io.ballerina.stdlib.kafka.plugin.KafkaCompilerPlugin"
 
 [[dependency]]
-path = "../compiler-plugin/build/libs/kafka-compiler-plugin-4.6.4.jar"
+path = "../compiler-plugin/build/libs/kafka-compiler-plugin-4.6.5-SNAPSHOT.jar"

--- a/ballerina/Dependencies.toml
+++ b/ballerina/Dependencies.toml
@@ -55,7 +55,7 @@ modules = [
 [[package]]
 org = "ballerina"
 name = "crypto"
-version = "2.9.2"
+version = "2.9.3"
 dependencies = [
 	{org = "ballerina", name = "jballerina.java"},
 	{org = "ballerina", name = "time"}
@@ -89,7 +89,7 @@ dependencies = [
 [[package]]
 org = "ballerina"
 name = "http"
-version = "2.14.9"
+version = "2.14.10"
 scope = "testOnly"
 dependencies = [
 	{org = "ballerina", name = "auth"},
@@ -411,7 +411,7 @@ modules = [
 [[package]]
 org = "ballerinax"
 name = "confluent.cavroserdes"
-version = "1.0.2"
+version = "1.0.3"
 dependencies = [
 	{org = "ballerina", name = "avro"},
 	{org = "ballerina", name = "jballerina.java"},
@@ -425,7 +425,7 @@ modules = [
 [[package]]
 org = "ballerinax"
 name = "confluent.cregistry"
-version = "0.4.3"
+version = "0.4.4"
 dependencies = [
 	{org = "ballerina", name = "jballerina.java"}
 ]
@@ -436,7 +436,7 @@ modules = [
 [[package]]
 org = "ballerinax"
 name = "kafka"
-version = "4.6.4"
+version = "4.6.5"
 dependencies = [
 	{org = "ballerina", name = "constraint"},
 	{org = "ballerina", name = "crypto"},

--- a/gradle.properties
+++ b/gradle.properties
@@ -11,7 +11,7 @@ downloadPluginVersion=5.4.0
 releasePluginVersion=2.8.0
 ballerinaGradlePluginVersion=2.3.0
 
-kafkaVersion=3.9.1
+kafkaVersion=3.9.2
 awaitalityVersion=4.2.2
 slf4jVersion=1.7.30
 testngVersion=7.6.1


### PR DESCRIPTION
## Purpose
> $subject

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Dependency Update for Enhanced Stability

This pull request updates the Kafka module and its dependencies to address security concerns and improve stability. The changes include:

**Version Updates:**
- Kafka module version incremented from `4.6.4` to `4.6.5`
- Apache Kafka client dependencies updated from version `3.9.1` to `3.9.2` (affecting both `kafka-clients` and `kafka_2.12`)
- Related platform dependencies updated: `ballerina:crypto` (2.9.2 → 2.9.3), `ballerina:http` (2.14.9 → 2.14.10), `ballerinax:confluent.cavroserdes` (1.0.2 → 1.0.3), and `ballerinax:confluent.cregistry` (0.4.3 → 0.4.4)

**Configuration Updates:**
- Updated compiler plugin JAR reference to use the new `kafka-compiler-plugin-4.6.5-SNAPSHOT.jar`
- Updated platform Java 21 dependency entries to reference the newer native JAR versions
- Updated `kafkaVersion` property in gradle.properties to `3.9.2`

The changes are reflected across configuration files including `Ballerina.toml`, `CompilerPlugin.toml`, `Dependencies.toml`, and `gradle.properties`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->