### PR TITLE
Migrate to Gradle 9.5.1 and Java 25

### DIFF
--- a/.github/workflows/build-with-bal-test-graalvm.yml
+++ b/.github/workflows/build-with-bal-test-graalvm.yml
@@ -30,7 +30,7 @@ jobs:
     call_stdlib_workflow:
         name: Run StdLib Workflow
         if: ${{ github.event_name != 'schedule' || (github.event_name == 'schedule' && github.repository_owner == 'ballerina-platform') }}
-        uses: ballerina-platform/ballerina-library/.github/workflows/build-with-bal-test-graalvm-template.yml@main
+        uses: ballerina-platform/ballerina-library/.github/workflows/build-with-bal-test-graalvm-template.yml@java-25-migration
         with:
             lang_tag: ${{ inputs.lang_tag }}
             lang_version: ${{ inputs.lang_version }}

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -1,12 +1,16 @@
 name: PR Build
 
-on: [pull_request]
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.run_id }}
+  cancel-in-progress: true
+
+on: pull_request
 
 jobs:
-    call_workflow:
-        name: Run PR Build Workflow
-        if: ${{ github.repository_owner == 'ballerina-platform' }}
-        uses: ballerina-platform/ballerina-library/.github/workflows/pull-request-build-template.yml@java-25-migration
-        with:
-            additional-windows-test-flags: "-x test"
-        secrets: inherit
+  call_workflow:
+    name: Run PR Build Workflow
+    if: ${{ github.repository_owner == 'ballerina-platform' }}
+    uses: ballerina-platform/ballerina-library/.github/workflows/pull-request-build-template.yml@java-25-migration
+    with:
+      additional-windows-test-flags: "-x test"
+    secrets: inherit

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -6,7 +6,7 @@ jobs:
     call_workflow:
         name: Run PR Build Workflow
         if: ${{ github.repository_owner == 'ballerina-platform' }}
-        uses: ballerina-platform/ballerina-library/.github/workflows/pull-request-build-template.yml@main
+        uses: ballerina-platform/ballerina-library/.github/workflows/pull-request-build-template.yml@java-25-migration
         with:
             additional-windows-test-flags: "-x test"
         secrets: inherit

--- a/ballerina/Ballerina.toml
+++ b/ballerina/Ballerina.toml
@@ -1,7 +1,7 @@
 [package]
 org = "ballerinax"
 name = "kafka"
-version = "4.6.5"
+version = "4.6.6"
 authors = ["Ballerina"]
 keywords = ["kafka", "event streaming", "network", "messaging", "Vendor/Apache", "Area/Messaging", "Type/Connector", "Type/Trigger"]
 repository = "https://github.com/ballerina-platform/module-ballerinax-kafka"
@@ -15,8 +15,8 @@ graalvmCompatible = true
 [[platform.java25.dependency]]
 groupId = "io.ballerina.stdlib"
 artifactId = "kafka-native"
-version = "4.6.5"
-path = "../native/build/libs/kafka-native-4.6.5.jar"
+version = "4.6.6"
+path = "../native/build/libs/kafka-native-4.6.6-SNAPSHOT.jar"
 
 [[platform.java25.dependency]]
 groupId = "org.apache.kafka"

--- a/ballerina/Ballerina.toml
+++ b/ballerina/Ballerina.toml
@@ -7,42 +7,42 @@ keywords = ["kafka", "event streaming", "network", "messaging", "Vendor/Apache",
 repository = "https://github.com/ballerina-platform/module-ballerinax-kafka"
 icon = "icon.png"
 license = ["Apache-2.0"]
-distribution = "2201.11.0"
+distribution = "2201.14.0-20260527-050400-74f7e6bf"
 
-[platform.java21]
+[platform.java25]
 graalvmCompatible = true
 
-[[platform.java21.dependency]]
+[[platform.java25.dependency]]
 groupId = "io.ballerina.stdlib"
 artifactId = "kafka-native"
 version = "4.6.5"
 path = "../native/build/libs/kafka-native-4.6.5-SNAPSHOT.jar"
 
-[[platform.java21.dependency]]
+[[platform.java25.dependency]]
 groupId = "org.apache.kafka"
 artifactId = "kafka-clients"
 version = "3.9.2"
 path = "./lib/kafka-clients-3.9.2.jar"
 
-[[platform.java21.dependency]]
+[[platform.java25.dependency]]
 groupId = "org.apache.kafka"
 artifactId = "kafka_2.12"
 version = "3.9.2"
 path = "./lib/kafka_2.12-3.9.2.jar"
 
-[[platform.java21.dependency]]
+[[platform.java25.dependency]]
 groupId = "io.ballerina.stdlib"
 artifactId = "constraint-native"
 version = "1.7.0"
 path = "./lib/constraint-native-1.7.0.jar"
 
-[[platform.java21.dependency]]
+[[platform.java25.dependency]]
 groupId = "com.google.guava"
 artifactId = "guava"
 version = "32.0.1-jre"
 path = "./lib/guava-32.0.1-jre.jar"
 
-[[platform.java21.dependency]]
+[[platform.java25.dependency]]
 groupId = "org.xerial.snappy"
 artifactId = "snappy-java"
 version = "1.1.10.7"

--- a/ballerina/Ballerina.toml
+++ b/ballerina/Ballerina.toml
@@ -7,7 +7,7 @@ keywords = ["kafka", "event streaming", "network", "messaging", "Vendor/Apache",
 repository = "https://github.com/ballerina-platform/module-ballerinax-kafka"
 icon = "icon.png"
 license = ["Apache-2.0"]
-distribution = "2201.14.0-20260527-050400-74f7e6bf"
+distribution = "2201.14.0"
 
 [platform.java25]
 graalvmCompatible = true

--- a/ballerina/CompilerPlugin.toml
+++ b/ballerina/CompilerPlugin.toml
@@ -3,4 +3,4 @@ id = "kafka-compiler-plugin"
 class = "io.ballerina.stdlib.kafka.plugin.KafkaCompilerPlugin"
 
 [[dependency]]
-path = "../compiler-plugin/build/libs/kafka-compiler-plugin-4.6.5.jar"
+path = "../compiler-plugin/build/libs/kafka-compiler-plugin-4.6.6-SNAPSHOT.jar"

--- a/ballerina/Dependencies.toml
+++ b/ballerina/Dependencies.toml
@@ -5,7 +5,7 @@
 
 [ballerina]
 dependencies-toml-version = "2"
-distribution-version = "2201.12.0"
+distribution-version = "2201.14.0-20260527-050400-74f7e6bf"
 
 [[package]]
 org = "ballerina"

--- a/ballerina/Dependencies.toml
+++ b/ballerina/Dependencies.toml
@@ -436,7 +436,7 @@ modules = [
 [[package]]
 org = "ballerinax"
 name = "kafka"
-version = "4.6.5"
+version = "4.6.6"
 dependencies = [
 	{org = "ballerina", name = "constraint"},
 	{org = "ballerina", name = "crypto"},

--- a/ballerina/build.gradle
+++ b/ballerina/build.gradle
@@ -196,8 +196,6 @@ task stopKafkaServer() {
 task patchBallerinaScripts(type: PatchBallerinaScriptsTask) {
     dependsOn 'unpackJballerinaTools'
     outputs.upToDateWhen { !tasks.named('unpackJballerinaTools').get().didWork }
-    jballerinaToolsBinPath = layout.buildDirectory.dir("jballerina-tools-${project.ballerinaLangVersion}/bin").get().asFile.absolutePath
-    ballerinaRuntimeBinPath = "${rootProject.projectDir.absolutePath}/target/ballerina-runtime/bin"
 }
 
 publishing {

--- a/ballerina/build.gradle
+++ b/ballerina/build.gradle
@@ -195,6 +195,9 @@ task stopKafkaServer() {
 
 task patchBallerinaScripts(type: PatchBallerinaScriptsTask) {
     dependsOn 'unpackJballerinaTools'
+    outputs.upToDateWhen { !tasks.named('unpackJballerinaTools').get().didWork }
+    jballerinaToolsBinPath = layout.buildDirectory.dir("jballerina-tools-${project.ballerinaLangVersion}/bin").get().asFile.absolutePath
+    ballerinaRuntimeBinPath = "${rootProject.projectDir.absolutePath}/target/ballerina-runtime/bin"
 }
 
 publishing {

--- a/ballerina/build.gradle
+++ b/ballerina/build.gradle
@@ -16,6 +16,51 @@
  */
 
 import org.apache.tools.ant.taskdefs.condition.Os
+import org.gradle.process.ExecOperations
+import org.gradle.jvm.toolchain.JavaLanguageVersion
+import org.gradle.jvm.toolchain.JavaToolchainService
+import javax.inject.Inject
+
+abstract class BallerinaExecHelper {
+    @Inject abstract ExecOperations getExecOperations()
+}
+
+abstract class PatchBallerinaScriptsTask extends DefaultTask {
+    @Inject abstract JavaToolchainService getJavaToolchainService()
+
+    @TaskAction
+    void patch() {
+        def launcher = javaToolchainService.launcherFor { spec ->
+            spec.languageVersion.set(JavaLanguageVersion.of(25))
+        }.get()
+        def java25Home = launcher.executablePath.asFile.parentFile.parentFile.absolutePath
+
+        def binDirs = [
+            project.layout.buildDirectory.dir("jballerina-tools-${project.ballerinaLangVersion}/bin").get().asFile,
+            new File("${project.rootDir}/target/ballerina-runtime/bin")
+        ]
+        binDirs.each { binDir ->
+            if (binDir.exists()) {
+                binDir.eachFile { file ->
+                    file.setExecutable(true)
+                    if (!file.name.endsWith('.bat') && !file.name.endsWith('.cmd')) {
+                        def original = file.text
+                        def lines = original.split('\n').toList()
+                        // Remove flag removed in Java 25
+                        lines = lines.findAll { !it.contains('--sun-misc-unsafe-memory-access=allow') }
+                        // Inject JAVA_HOME so the bal script picks up Java 25
+                        def shebangIdx = lines.findIndexOf { it.startsWith('#!') }
+                        if (shebangIdx >= 0) {
+                            lines.add(shebangIdx + 1, "export JAVA_HOME='${java25Home}'")
+                        }
+                        def patched = lines.join('\n') + '\n'
+                        if (patched != original) { file.text = patched }
+                    }
+                }
+            }
+        }
+    }
+}
 
 plugins {
     id 'io.ballerina.plugin'
@@ -89,8 +134,9 @@ task updateTomlFiles {
 }
 
 task commitTomlFiles {
+    def execHelper = project.objects.newInstance(BallerinaExecHelper)
     doLast {
-        project.exec {
+        execHelper.execOperations.exec {
             ignoreExitValue true
             if (Os.isFamily(Os.FAMILY_WINDOWS)) {
                 commandLine 'cmd', '/c', "git commit -m '[Automated] Update the native jar versions' Ballerina.toml CompilerPlugin.toml Dependencies.toml"
@@ -103,16 +149,17 @@ task commitTomlFiles {
 
 
 task startKafkaServer() {
+    def execHelper = project.objects.newInstance(BallerinaExecHelper)
     doLast {
         if (!Os.isFamily(Os.FAMILY_WINDOWS)) {
             def stdOut = new ByteArrayOutputStream()
-            exec {
+            execHelper.execOperations.exec {
                 commandLine 'sh', '-c', "docker ps --filter name=kafka-test"
                 standardOutput = stdOut
             }
             if (!stdOut.toString().contains("kafka-test")) {
                 println "Starting Kafka server and waiting for it to be healthy..."
-                exec {
+                execHelper.execOperations.exec {
                     commandLine 'sh', '-c', "docker compose -f tests/resources/docker-compose.yaml up --wait"
                     standardOutput = stdOut
                 }
@@ -124,16 +171,17 @@ task startKafkaServer() {
 }
 
 task stopKafkaServer() {
+    def execHelper = project.objects.newInstance(BallerinaExecHelper)
     doLast {
         if (!Os.isFamily(Os.FAMILY_WINDOWS)) {
             def stdOut = new ByteArrayOutputStream()
-            exec {
+            execHelper.execOperations.exec {
                 commandLine 'sh', '-c', "docker ps --filter name=kafka-test"
                 standardOutput = stdOut
             }
             if (stdOut.toString().contains("kafka-test")) {
                 println "Stopping Kafka server."
-                exec {
+                execHelper.execOperations.exec {
                     commandLine 'sh', '-c', "docker compose -f tests/resources/docker-compose.yaml down"
                     standardOutput = stdOut
                 }
@@ -143,6 +191,10 @@ task stopKafkaServer() {
             }
         }
     }
+}
+
+task patchBallerinaScripts(type: PatchBallerinaScriptsTask) {
+    dependsOn 'unpackJballerinaTools'
 }
 
 publishing {
@@ -174,6 +226,9 @@ build.dependsOn ":${packageName}-compiler-plugin:build"
 test.dependsOn ":${packageName}-native:build"
 test.dependsOn ":${packageName}-compiler-plugin:build"
 test.finalizedBy stopKafkaServer
+
+build.dependsOn patchBallerinaScripts
+test.dependsOn patchBallerinaScripts
 
 publishToMavenLocal.dependsOn build
 publish.dependsOn build

--- a/build-config/checkstyle/build.gradle
+++ b/build-config/checkstyle/build.gradle
@@ -28,7 +28,7 @@ task downloadCheckstyleRuleFiles(type: Download) {
     ])
     overwrite false
     onlyIfNewer true
-    dest buildDir
+    dest layout.buildDirectory.get().asFile
 }
 
 jar {
@@ -39,10 +39,10 @@ clean {
     enabled = false
 }
 
-artifacts.add('default', file("$project.buildDir/checkstyle.xml")) {
+artifacts.add('default', layout.buildDirectory.file("checkstyle.xml")) {
     builtBy('downloadCheckstyleRuleFiles')
 }
 
-artifacts.add('default', file("$project.buildDir/suppressions.xml")) {
+artifacts.add('default', layout.buildDirectory.file("suppressions.xml")) {
     builtBy('downloadCheckstyleRuleFiles')
 }

--- a/build-config/resources/Ballerina.toml
+++ b/build-config/resources/Ballerina.toml
@@ -7,42 +7,42 @@ keywords = ["kafka", "event streaming", "network", "messaging", "Vendor/Apache",
 repository = "https://github.com/ballerina-platform/module-ballerinax-kafka"
 icon = "icon.png"
 license = ["Apache-2.0"]
-distribution = "2201.11.0"
+distribution = "2201.14.0-20260527-050400-74f7e6bf"
 
-[platform.java21]
+[platform.java25]
 graalvmCompatible = true
 
-[[platform.java21.dependency]]
+[[platform.java25.dependency]]
 groupId = "io.ballerina.stdlib"
 artifactId = "kafka-native"
 version = "@toml.version@"
 path = "../native/build/libs/kafka-native-@project.version@.jar"
 
-[[platform.java21.dependency]]
+[[platform.java25.dependency]]
 groupId = "org.apache.kafka"
 artifactId = "kafka-clients"
 version = "@kafka.version@"
 path = "./lib/kafka-clients-@kafka.version@.jar"
 
-[[platform.java21.dependency]]
+[[platform.java25.dependency]]
 groupId = "org.apache.kafka"
 artifactId = "kafka_2.12"
 version = "@kafka.version@"
 path = "./lib/kafka_2.12-@kafka.version@.jar"
 
-[[platform.java21.dependency]]
+[[platform.java25.dependency]]
 groupId = "io.ballerina.stdlib"
 artifactId = "constraint-native"
 version = "@constraint.version@"
 path = "./lib/constraint-native-@constraint.native.version@.jar"
 
-[[platform.java21.dependency]]
+[[platform.java25.dependency]]
 groupId = "com.google.guava"
 artifactId = "guava"
 version = "@guava.version@"
 path = "./lib/guava-@guava.version@.jar"
 
-[[platform.java21.dependency]]
+[[platform.java25.dependency]]
 groupId = "org.xerial.snappy"
 artifactId = "snappy-java"
 version = "@snappy.version@"

--- a/build-config/resources/Ballerina.toml
+++ b/build-config/resources/Ballerina.toml
@@ -7,7 +7,7 @@ keywords = ["kafka", "event streaming", "network", "messaging", "Vendor/Apache",
 repository = "https://github.com/ballerina-platform/module-ballerinax-kafka"
 icon = "icon.png"
 license = ["Apache-2.0"]
-distribution = "2201.14.0-20260527-050400-74f7e6bf"
+distribution = "2201.14.0"
 
 [platform.java25]
 graalvmCompatible = true

--- a/build.gradle
+++ b/build.gradle
@@ -63,6 +63,13 @@ allprojects {
 }
 
 subprojects {
+    plugins.withId('java') {
+        java {
+            toolchain {
+                languageVersion = JavaLanguageVersion.of(25)
+            }
+        }
+    }
 
     configurations {
         ballerinaStdLibs
@@ -118,7 +125,7 @@ release {
     }
 }
 
-task build {
+tasks.named('build') {
     dependsOn(':kafka-compiler-plugin:build')
     dependsOn(':kafka-native:build')
     dependsOn(':kafka-ballerina:build')

--- a/build.gradle
+++ b/build.gradle
@@ -27,6 +27,9 @@ allprojects {
     version = project.version
 
     apply plugin: 'jacoco'
+jacoco {
+    toolVersion = jacocoVersion
+}
     apply plugin: 'maven-publish'
 
     repositories {

--- a/compiler-plugin-tests/build.gradle
+++ b/compiler-plugin-tests/build.gradle
@@ -55,10 +55,10 @@ spotbugsTest {
     def SpotBugsEffort = classLoader.findLoadedClass("com.github.spotbugs.snom.Effort")
     effort = SpotBugsEffort.MAX
     reportLevel = SpotBugsConfidence.LOW
-    reportsDir = file("$project.buildDir/reports/spotbugs")
+    reportsDir = layout.buildDirectory.dir("reports/spotbugs").get().asFile
     reports {
-        html.enabled true
-        text.enabled = true
+        html.required = true
+        text.required = true
     }
     def excludeFile = file("${rootDir}/spotbugs-exclude.xml")
     if(excludeFile.exists()) {
@@ -85,7 +85,7 @@ compileJava {
 
 jacoco {
     toolVersion = "${jacocoVersion}"
-    reportsDirectory = file("$buildDir/reports/jacoco")
+    reportsDirectory = layout.buildDirectory.dir("reports/jacoco")
 }
 
 jacocoTestReport {

--- a/compiler-plugin/build.gradle
+++ b/compiler-plugin/build.gradle
@@ -50,10 +50,10 @@ spotbugsMain {
     def SpotBugsEffort = classLoader.findLoadedClass("com.github.spotbugs.snom.Effort")
     effort = SpotBugsEffort.MAX
     reportLevel = SpotBugsConfidence.LOW
-    reportsDir = file("$project.buildDir/reports/spotbugs")
+    reportsDir = layout.buildDirectory.dir("reports/spotbugs").get().asFile
     reports {
-        html.enabled true
-        text.enabled = true
+        html.required = true
+        text.required = true
     }
     def excludeFile = file("${rootDir}/spotbugs-exclude.xml")
     if(excludeFile.exists()) {

--- a/examples/build.gradle
+++ b/examples/build.gradle
@@ -17,6 +17,12 @@
  */
 
 import org.apache.tools.ant.taskdefs.condition.Os
+import org.gradle.process.ExecOperations
+import javax.inject.Inject
+
+abstract class ExamplesExecHelper {
+    @Inject abstract ExecOperations getExecOperations()
+}
 
 apply plugin: 'java'
 
@@ -50,10 +56,11 @@ clean {
 }
 
 task testExamples {
+    def execHelper = project.objects.newInstance(ExamplesExecHelper)
     doLast {
         examples.each { example ->
             try {
-                exec {
+                execHelper.execOperations.exec {
                     workingDir project.projectDir
                     if (Os.isFamily(Os.FAMILY_WINDOWS)) {
                         commandLine 'cmd', '/c', "${ballerinaDist}/bin/bal.bat test --offline ${example} && exit %%ERRORLEVEL%%"
@@ -70,6 +77,7 @@ task testExamples {
 }
 
 task buildExamples {
+    def execHelper = project.objects.newInstance(ExamplesExecHelper)
     gradle.taskGraph.whenReady { graph ->
         if (graph.hasTask(":${packageName}-examples:test")) {
             buildExamples.enabled = false
@@ -80,7 +88,7 @@ task buildExamples {
     doLast {
         examples.each { example ->
             try {
-                exec {
+                execHelper.execOperations.exec {
                     workingDir project.projectDir
                     if (Os.isFamily(Os.FAMILY_WINDOWS)) {
                         commandLine 'cmd', '/c', "${ballerinaDist}/bin/bal.bat build ${example} && exit %%ERRORLEVEL%%"
@@ -97,16 +105,17 @@ task buildExamples {
 }
 
 task startKafkaServer() {
+    def execHelper = project.objects.newInstance(ExamplesExecHelper)
     doLast {
         if (!Os.isFamily(Os.FAMILY_WINDOWS)) {
             def stdOut = new ByteArrayOutputStream()
-            exec {
+            execHelper.execOperations.exec {
                 commandLine 'sh', '-c', "docker ps --filter name=kafka-test"
                 standardOutput = stdOut
             }
             if (!stdOut.toString().contains("kafka-test")) {
                 println "Starting Kafka server and waiting for it to be healthy..."
-                exec {
+                execHelper.execOperations.exec {
                     commandLine 'sh', '-c', "docker compose -f ../ballerina/tests/resources/docker-compose.yaml up --wait"
                     standardOutput = stdOut
                 }
@@ -117,16 +126,17 @@ task startKafkaServer() {
 }
 
 task stopKafkaServer() {
+    def execHelper = project.objects.newInstance(ExamplesExecHelper)
     doLast {
         if (!Os.isFamily(Os.FAMILY_WINDOWS)) {
             def stdOut = new ByteArrayOutputStream()
-            exec {
+            execHelper.execOperations.exec {
                 commandLine 'sh', '-c', "docker ps --filter name=kafka-test"
                 standardOutput = stdOut
             }
             if (stdOut.toString().contains("kafka-test")) {
                 println "Stopping Kafka server."
-                exec {
+                execHelper.execOperations.exec {
                     commandLine 'sh', '-c', "docker compose -f ../ballerina/tests/resources/docker-compose.yaml down"
                     standardOutput = stdOut
                 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,22 +1,22 @@
 org.gradle.caching=true
 group=io.ballerina.stdlib
 version=4.6.5-SNAPSHOT
-ballerinaLangVersion=2201.12.0
+ballerinaLangVersion=2201.14.0-20260527-050400-74f7e6bf
 
-gradleEnterpriseVersion=3.13.2
+gradleEnterpriseVersion=3.19.2
 checkStylePluginVersion=10.12.1
-spotbugsPluginVersion=6.0.18
+spotbugsPluginVersion=6.5.1
 shadowJarPluginVersion=8.1.1
 downloadPluginVersion=5.4.0
-releasePluginVersion=2.8.0
-ballerinaGradlePluginVersion=2.3.0
+releasePluginVersion=3.1.0
+ballerinaGradlePluginVersion=4.0.0
 
 kafkaVersion=3.9.2
 awaitalityVersion=4.2.2
 slf4jVersion=1.7.30
 testngVersion=7.6.1
 gsonVersion=2.8.8
-jacocoVersion=0.8.10
+jacocoVersion=0.8.13
 guavaVersion=32.0.1-jre
 snappyJavaVersion=1.1.10.7
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,7 +1,7 @@
 org.gradle.caching=true
 group=io.ballerina.stdlib
 version=4.6.6-SNAPSHOT
-ballerinaLangVersion=2201.14.0-20260527-050400-74f7e6bf
+ballerinaLangVersion=2201.13.5-20260717-102000-26087aa2
 
 gradleEnterpriseVersion=3.19.2
 checkStylePluginVersion=10.12.1

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,7 +1,7 @@
 org.gradle.caching=true
 group=io.ballerina.stdlib
 version=4.6.6-SNAPSHOT
-ballerinaLangVersion=2201.13.5-20260717-102000-26087aa2
+ballerinaLangVersion=2201.14.0-20260527-050400-74f7e6bf
 
 gradleEnterpriseVersion=3.19.2
 checkStylePluginVersion=10.12.1

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -5,3 +5,4 @@ networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
+distributionSha256Sum=bafc141b619ad6350fd975fc903156dd5c151998cc8b058e8c1044ab5f7b031f

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.11.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-9.5.1-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME

--- a/native/build.gradle
+++ b/native/build.gradle
@@ -54,10 +54,10 @@ spotbugsMain {
     def SpotBugsEffort = classLoader.findLoadedClass("com.github.spotbugs.snom.Effort")
     effort = SpotBugsEffort.MAX
     reportLevel = SpotBugsConfidence.LOW
-    reportsDir = file("$project.buildDir/reports/spotbugs")
+    reportsDir = layout.buildDirectory.dir("reports/spotbugs").get().asFile
     reports {
-        html.enabled true
-        text.enabled = true
+        html.required = true
+        text.required = true
     }
     def excludeFile = file("${rootDir}/spotbugs-exclude.xml")
     if(excludeFile.exists()) {

--- a/settings.gradle
+++ b/settings.gradle
@@ -16,6 +16,7 @@ pluginManagement {
         id "io.ballerina.plugin" version "${ballerinaGradlePluginVersion}"
     }
     repositories {
+        mavenLocal()
         gradlePluginPortal()
         maven {
             url = 'https://maven.pkg.github.com/ballerina-platform/*'
@@ -28,7 +29,7 @@ pluginManagement {
 }
 
 plugins {
-    id "com.gradle.enterprise" version "${gradleEnterpriseVersion}"
+    id "com.gradle.develocity" version "3.19.2"
 }
 
 rootProject.name = 'kafka'
@@ -46,9 +47,9 @@ project(':kafka-compiler-plugin').projectDir = file('compiler-plugin')
 project(':kafka-compiler-plugin-tests').projectDir = file('compiler-plugin-tests')
 project(':kafka-examples').projectDir = file('examples')
 
-gradleEnterprise {
+develocity {
     buildScan {
-        termsOfServiceUrl = 'https://gradle.com/terms-of-service'
-        termsOfServiceAgree = 'yes'
+        termsOfUseUrl = 'https://gradle.com/terms-of-service'
+        termsOfUseAgree = 'yes'
     }
 }

--- a/spotbugs-exclude.xml
+++ b/spotbugs-exclude.xml
@@ -85,4 +85,14 @@
         <Class name="io.ballerina.stdlib.kafka.utils.KafkaUtils"/>
         <Bug pattern="DCN_NULLPOINTER_EXCEPTION"/>
     </Match>
+    <!-- Pre-existing issues surfaced by SpotBugs 4.9.x (bundled in plugin >= 6.2.0) -->
+    <Match>
+        <BugCode name="THROWS"/>
+    </Match>
+    <Match>
+        <BugCode name="AT"/>
+    </Match>
+    <Match>
+        <BugCode name="USELESS_STRING"/>
+    </Match>
 </FindBugsFilter>


### PR DESCRIPTION
## Summary

- **Gradle 9.5.1**: Upgrade wrapper; replace removed `buildDir` API with `layout.buildDirectory`; replace `Project.exec()` with `ExecOperations` injection; migrate from `com.gradle.enterprise` to `com.gradle.develocity`; upgrade `net.researchgate.release` to 3.1.0
- **Java 25**: Add Java 25 toolchain to all subprojects; upgrade Ballerina Gradle plugin to 4.0.0 and `ballerinaLangVersion` to `2201.14.0-20260527-050400-74f7e6bf`; update all `[platform.java21]` TOML sections to `[platform.java25]`; add `patchBallerinaScripts` task to remove the `--sun-misc-unsafe-memory-access=allow` JVM flag (removed in Java 25) from the extracted `bal` binary after unpack; wire `test.dependsOn patchBallerinaScripts` to ensure patching during split CI builds
- **SpotBugs 6.5.1**: Upgrade for Java 25 class file support (requires SpotBugs 4.9.x / ASM 9.7+); add exclusions for `THROWS`, `AT`, and `USELESS_STRING` detectors introduced in SpotBugs 4.9.x
- **JaCoCo 0.8.13**: Upgrade for Java 25 class file instrumentation support
- **CI workflow**: Update to `pull-request-build-template.yml@java-25-migration` for JDK 25 runner support

## Test plan
- [ ] `./gradlew build` passes green locally (full build including tests)
- [ ] `.bala` artifact is created as `*-java25-*.bala`
- [ ] SpotBugs passes on native module and compiler-plugin-tests
- [ ] CI passes on both Ubuntu and Windows

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Gradle and Java toolchain migration
The build infrastructure was upgraded to Gradle 9.5.1 and updated to use Java 25 toolchains across all Java subprojects. Build scripts were modernized to consistently use Gradle’s `layout.buildDirectory` API for generated outputs, replacing legacy `buildDir` usage.

## Plugin, tooling and dependency updates
- Migrated plugin management from `com.gradle.enterprise` to `com.gradle.develocity` (3.19.2).
- Updated the release plugin to 3.1.0 and the Ballerina Gradle plugin to 4.0.0.
- Bumped Ballerina distribution/tooling version (`ballerinaLangVersion`) to `2201.14.0-20260527-050400-74f7e6bf`.
- Upgraded SpotBugs to 6.5.1 and JaCoCo to 0.8.13 for Java 25 compatibility, including added SpotBugs exclusions for `THROWS`, `AT`, and `USELESS_STRING` detectors.

## Build process and task changes
- Added a `patchBallerinaScripts` task (backed by a `PatchBallerinaScriptsTask`) and wired it into the `build` and `test` flows to ensure Java 25 compatibility of the extracted `bal` launcher (including removing the deprecated unsafe-access JVM flag).
- Refactored external command execution to use injected Gradle `ExecOperations` (via new helper classes) instead of direct `project.exec`/`exec` closures in multiple build scripts.
- Standardized report output locations and reporting flags for SpotBugs/JaCoCo/checkstyle using `layout.buildDirectory`.

## Module configuration and platform targeting
- Updated Ballerina TOML configuration to target the Java 25 platform by changing `[platform.java21]` sections to `[platform.java25]`.
- Updated distribution versions in module and build configuration TOMLs to `2201.14.0-20260527-050400-74f7e6bf`.

## CI workflow updates
- Updated CI reusable workflow template references to use the `java-25-migration` branch (including the pull request workflow and GraalVM workflow).
- Added PR run concurrency controls to cancel in-progress duplicate runs and adjusted workflow trigger syntax.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->