### PR TITLE
Bump confluent versions

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -45,8 +45,8 @@ stdlibOAuth2Version=2.14.1
 stdlibHttpVersion=2.14.8
 
 stdlibTransactionVersion=1.12.0
-confluentAvroSerDesVersion=1.0.2
-confluentRegistryVersion=0.4.2
+confluentAvroSerDesVersion=1.0.3
+confluentRegistryVersion=0.4.4
 
 # Ballerinax Observer
 observeVersion=1.5.1


### PR DESCRIPTION
## Purpose

## Examples

## Checklist
- [ ] Linked to an issue
- [ ] Updated the changelog
- [ ] Added tests
- [ ] Updated the spec
- [ ] Checked native-image compatibility


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
This pull request updates Confluent-related dependency version properties in gradle.properties to keep build dependencies current:

- Bumped confluentAvroSerDesVersion from 1.0.2 to 1.0.3
- Bumped confluentRegistryVersion from 0.4.2 to 0.4.4

Intent: refresh dependency handling so the project benefits from the latest upstream improvements and fixes in these Confluent components.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->